### PR TITLE
Add --install-skill for agent skills and Cursor rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,8 +192,8 @@ npx @raymondchins/agentmap --install-skill
 ```
 
 Copies a packaged **SKILL.md** (Claude Code / Codex / OpenCode) and a **Cursor rule**
-(`.cursor/rules/agentmap.mdc`, `alwaysApply: true`) into the current repo — same idea as
-[Graphify](https://graphify.net/)'s `graphify install`, but agentmap-native. Options:
+(`.cursor/rules/agentmap.mdc`, `alwaysApply: true`) into the current repo or global
+agent directories. Options:
 
 ```bash
 agentmap --install-skill --platform cursor      # Cursor rule only

--- a/README.md
+++ b/README.md
@@ -185,6 +185,25 @@ internally on `tool_name`. For reference, or to wire it by hand:
 That's the "forced to use it" in the tagline: the map stays current on its own, and the
 agent is steered to it the moment it reaches for a dependency-shaped grep or Bash search.
 
+### 3. Agent skills (Cursor, Claude Code, Codex)
+
+```bash
+npx @raymondchins/agentmap --install-skill
+```
+
+Copies a packaged **SKILL.md** (Claude Code / Codex / OpenCode) and a **Cursor rule**
+(`.cursor/rules/agentmap.mdc`, `alwaysApply: true`) into the current repo — same idea as
+[Graphify](https://graphify.net/)'s `graphify install`, but agentmap-native. Options:
+
+```bash
+agentmap --install-skill --platform cursor      # Cursor rule only
+agentmap --install-skill --platform claude      # .claude/skills/agentmap/SKILL.md
+agentmap --install-skill --global --platform claude  # ~/.claude/skills/...
+agentmap --install-skill --dry-run              # preview paths, no writes
+```
+
+Pair with `--install-hooks` (Claude Code) or `--mcp` (Cursor MCP).
+
 ---
 
 ## Quickstart
@@ -481,6 +500,7 @@ $ node agentmap.mjs --print | jq '.hubs[0]'
 | `--version` / `-v` | Print the version from `package.json` and exit 0. |
 | `--json` | **Global modifier.** When present, every command prints exactly one JSON object to stdout (no prose). Shapes vary per command: `--json --hubs` → `{command,fileCount,sha,hubs:[string]}`, `--json --find X` → `{command,query,matches:[{file,name,kind}]}`, `--json --relates X` → `{command,file,pagerank,exports,imports,dependents,related}`, `--json --any X` → `{command,query,kind,…payload}`, etc. Bare `--json` (no query flag) → `{command:"build",fileCount,features,topHub}`. |
 | `--install-hooks` | Copy `hooks/post-commit` into `.git/hooks/` (chmod 0755), ensure `.claude/agentmap.json` is in `.gitignore`, and auto-wire the Claude Code `PreToolUse(Grep)` nudge into `.claude/settings.json` (merge-safe + idempotent). Exit 0 on success, stderr + exit 1 on failure. |
+| `--install-skill` | Install packaged agent skill + Cursor rule (`--platform claude\|cursor\|agents\|all`, default `all`; `--project` default, or `--global`; `--dry-run` preview). |
 | `--mcp` | Start agentmap as a **stdio MCP server** so non-Claude-Code agents (Cursor, Cline, any MCP client) can call every flag as a first-class tool. |
 
 **Exit-code contract:** `0` = success / match / help / version; `1` = query returned zero results (`--any`, `--find`, `--relates`, `--feature` with no match); `2` = usage error (missing required arg, unknown flag). Any token starting with `-` that matches no known flag prints an error to stderr and exits 2.

--- a/agentmap.mjs
+++ b/agentmap.mjs
@@ -20,7 +20,6 @@ import { createRequire } from "node:module";
 import { homedir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { join, dirname } from "node:path";
-import { installSkill } from "./skills/install.mjs";
 
 // Lazy ts-morph: its ~105ms module init only fires on a COLD rebuild. Warm cache
 // queries (the common case) never construct a Project, so they skip the load
@@ -1009,6 +1008,9 @@ else if (has("--install-hooks")) {
 // --install-skill: copy packaged SKILL.md / Cursor rule (see skills/install.mjs).
 else if (has("--install-skill")) {
   try {
+    // lazy import keeps skills/install.mjs (and its package.json read) OFF the
+    // hot path — warm --any/--find queries must not load it.
+    const { installSkill } = await import("./skills/install.mjs");
     installSkill({
       platforms: arg("--platform") || "all",
       project: !has("--global"),

--- a/agentmap.mjs
+++ b/agentmap.mjs
@@ -20,6 +20,7 @@ import { createRequire } from "node:module";
 import { homedir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { join, dirname } from "node:path";
+import { installSkill } from "./skills/install.mjs";
 
 // Lazy ts-morph: its ~105ms module init only fires on a COLD rebuild. Warm cache
 // queries (the common case) never construct a Project, so they skip the load
@@ -927,7 +928,8 @@ const out = (obj, prose) => { if (wantJson) console.log(JSON.stringify(obj)); el
 // NOT in this set is an unknown flag → usage error (exit 2), not a silent build.
 const KNOWN = new Set([
   "--json", "--print",
-  "--help", "-h", "--version", "-v", "--install-hooks", "--dry-run", "--setup-mcp", "--mcp",
+  "--help", "-h", "--version", "-v", "--install-hooks", "--install-skill", "--platform", "--project", "--global",
+  "--dry-run", "--setup-mcp", "--mcp",
   "--any", "--find", "--relates", "--map", "--focus", "--tokens",
   "--symbols", "--feature", "--features", "--hubs",
 ]);
@@ -936,7 +938,7 @@ const KNOWN = new Set([
 // so a dash-leading query like `--any "-O/bin/sh"` is bound as the query, not
 // mistaken for an unknown flag. (arg() already rejects a "--"-leading value, so
 // `--any --foo` still falls through to the missing-arg guard instead.)
-const VALUE_FLAGS = new Set(["--any", "--find", "--relates", "--feature", "--focus", "--tokens", "--symbols"]);
+const VALUE_FLAGS = new Set(["--any", "--find", "--relates", "--feature", "--focus", "--tokens", "--symbols", "--platform"]);
 const valueIdx = new Set();
 for (let i = 0; i < args.length - 1; i++) if (VALUE_FLAGS.has(args[i])) valueIdx.add(i + 1);
 
@@ -964,6 +966,8 @@ Maintenance:
   --install-hooks [--dry-run]
                        install git post-commit + copy the PreToolUse nudge +
                        wire .claude/settings.json (--dry-run = preview, no writes)
+  --install-skill [--platform claude|cursor|agents|all] [--project|--global] [--dry-run]
+                       install SKILL.md / Cursor rule for coding agents
   --setup-mcp [--dry-run]
                        configure MCP server for OpenCode & Antigravity IDE
                        (--dry-run = preview, no writes)
@@ -1001,6 +1005,21 @@ if (has("--mcp")) {
 else if (has("--install-hooks")) {
   try { installHooks({ dryRun: has("--dry-run") }); process.exit(0); }
   catch (e) { console.error(`agentmap --install-hooks failed: ${e?.message || e}`); process.exit(1); }
+}
+// --install-skill: copy packaged SKILL.md / Cursor rule (see skills/install.mjs).
+else if (has("--install-skill")) {
+  try {
+    installSkill({
+      platforms: arg("--platform") || "all",
+      project: !has("--global"),
+      global: has("--global"),
+      dryRun: has("--dry-run"),
+    });
+    process.exit(0);
+  } catch (e) {
+    console.error(`agentmap --install-skill failed: ${e?.message || e}`);
+    process.exit(1);
+  }
 }
 // --setup-mcp: configure MCP server for OpenCode & Antigravity IDE.
 else if (has("--setup-mcp")) {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "agentmap.mjs",
     "mcp.mjs",
     "hooks",
+    "skills",
     "NOTICE"
   ],
   "scripts": {

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: agentmap
+description: >-
+  Use for TypeScript/JavaScript codebase navigation — symbol lookup, blast radius,
+  reuse checks, and repo orientation. Prefer agentmap before serial grep when
+  exploring imports, exports, or where a symbol lives. Package is
+  @raymondchins/agentmap (not the unrelated npm package agentmap).
+---
+
+# agentmap
+
+Queryable, ranked **import graph** for TS/JS repos (PageRank hubs, symbol ranking, token-budgeted digest). Faster and more accurate than grep for structural questions.
+
+## When to use
+
+- **Where is X defined?** / **who imports this file?** / **what breaks if I edit this?**
+- **Reuse check** before adding a util, component, or type
+- **Session start** — orient to a large monorepo cheaply
+
+## When not to use
+
+- Raw string / config value search (try `agentmap --any` first — layer 4 is live `git grep`)
+- Non-TS/JS files, runtime call graphs, or full semantic "how does it work?" (use codebase search)
+- Next-style `--feature` on TanStack Router / non-`app/` layouts (often empty)
+
+## Commands (run in repo root)
+
+```bash
+# Smart router — default first move
+agentmap --any <query>
+
+# Reuse / symbol definition
+agentmap --find <SymbolName>
+
+# Blast radius (exports, imports, dependents, related files)
+agentmap --relates <path/to/file.ts>
+
+# Token-budgeted ranked digest
+agentmap --map --tokens 400
+agentmap --map --focus <path> --tokens 400
+
+# Hub files (PageRank)
+agentmap --hubs
+
+# JSON for tools
+agentmap --json --any <query>
+```
+
+Install: `npm i -g @raymondchins/agentmap` or `npx @raymondchins/agentmap`. Map cache: `.claude/agentmap/` (gitignored).
+
+## Agent platforms
+
+| Platform | Setup |
+|----------|--------|
+| **Claude Code** | `agentmap --install-hooks` (post-commit refresh + PreToolUse grep nudge) |
+| **Cursor / MCP clients** | `agentmap --mcp` in MCP config, or Shell + commands above |
+| **This skill** | `agentmap --install-skill` |
+
+## Workflow
+
+1. If the map may be stale after edits, run `agentmap` (no flags) or rely on post-commit hook.
+2. Start with `agentmap --any <symbol or topic>`.
+3. Before editing a hub file, run `agentmap --relates <that-file>`.
+4. Fall back to grep only when agentmap returns no useful structure hit.
+
+## Package name
+
+```bash
+npx @raymondchins/agentmap --any Procedure
+# NOT: npm install agentmap  (different package)
+```

--- a/skills/cursor-rule.mdc
+++ b/skills/cursor-rule.mdc
@@ -1,0 +1,27 @@
+---
+description: agentmap ranked TS/JS repo map
+alwaysApply: true
+---
+
+This project can use **agentmap** (`@raymondchins/agentmap`) — a queryable import/symbol map at `.claude/agentmap/`.
+
+**Before Grep/Glob for structural questions** (where is a symbol, who imports a file, reuse check, blast radius), prefer:
+
+```bash
+agentmap --any <query>          # file → symbol → feature → git-grep fallback
+agentmap --find <Symbol>        # exported symbols matching name
+agentmap --relates <file.ts>    # imports, dependents, related files
+agentmap --map --tokens 400     # cheap repo orientation
+```
+
+Use Read/Grep directly when:
+
+1. agentmap already oriented you and you need exact lines to edit
+2. The map is missing — run `agentmap` once to build `.claude/agentmap/`
+3. Searching raw strings, logs, or non-TS files
+
+**Cursor MCP (optional):** `agentmap --mcp` exposes the same queries as tools.
+
+**Note:** `--features` only detects Next.js `app/` routes; TanStack `src/routes/` repos often show `features (0)`.
+
+Package: `@raymondchins/agentmap` — not the unrelated PyPI/npm `agentmap` package.

--- a/skills/install.mjs
+++ b/skills/install.mjs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // --install-skill: copy packaged SKILL.md / Cursor rule into project or global
-// agent directories (pattern inspired by graphify's graphify install).
+// agent directories (project or global scope).
 
 import { readFileSync, writeFileSync, mkdirSync, existsSync, renameSync } from "node:fs";
 import { homedir } from "node:os";

--- a/skills/install.mjs
+++ b/skills/install.mjs
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: MIT
+// --install-skill: copy packaged SKILL.md / Cursor rule into project or global
+// agent directories (pattern inspired by graphify's graphify install).
+
+import { readFileSync, writeFileSync, mkdirSync, existsSync, renameSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SKILLS_DIR = dirname(fileURLToPath(import.meta.url));
+const VERSION = JSON.parse(readFileSync(join(SKILLS_DIR, "..", "package.json"), "utf8")).version;
+
+/** @type {Record<string, { label: string; src: string; dest: (root: string) => string; projectOnly?: boolean }>} */
+const PLATFORMS = {
+  claude: {
+    label: "Claude Code",
+    src: join(SKILLS_DIR, "SKILL.md"),
+    dest: (root) => join(root, ".claude", "skills", "agentmap", "SKILL.md"),
+  },
+  agents: {
+    label: "Codex / OpenCode (.agents)",
+    src: join(SKILLS_DIR, "SKILL.md"),
+    dest: (root) => join(root, ".agents", "skills", "agentmap", "SKILL.md"),
+  },
+  cursor: {
+    label: "Cursor",
+    src: join(SKILLS_DIR, "cursor-rule.mdc"),
+    dest: (root) => join(root, ".cursor", "rules", "agentmap.mdc"),
+    projectOnly: true,
+  },
+};
+
+function atomicWrite(dest, body) {
+  mkdirSync(dirname(dest), { recursive: true });
+  const tmp = `${dest}.tmp`;
+  writeFileSync(tmp, body, "utf8");
+  renameSync(tmp, dest);
+}
+
+function parsePlatforms(raw) {
+  if (!raw || raw === "all") return ["claude", "cursor", "agents"];
+  const names = raw.split(/[,+]/).map((s) => s.trim().toLowerCase()).filter(Boolean);
+  for (const n of names) {
+    if (!PLATFORMS[n]) {
+      throw new Error(`unknown platform '${n}' — choose: ${Object.keys(PLATFORMS).join(", ")}, all`);
+    }
+  }
+  return names;
+}
+
+function gitAddHint(paths) {
+  const unique = [...new Set(paths.map((p) => p.replace(/\/[^/]+$/, "") || p))];
+  if (unique.length) console.log(`\nOptional: git add ${unique.map((p) => `"${p}"`).join(" ")}`);
+}
+
+/**
+ * @param {{ platforms?: string; project?: boolean; global?: boolean; dryRun?: boolean }} opts
+ */
+export function installSkill({ platforms: platformsArg = "all", project = true, global: globalScope = false, dryRun = false } = {}) {
+  if (project && globalScope) throw new Error("use either --project or --global, not both");
+  const scope = globalScope ? "global" : "project";
+  const root = globalScope ? homedir() : process.cwd();
+  const names = parsePlatforms(platformsArg);
+  const targets = [];
+
+  if (dryRun) console.log(`--dry-run: would install agentmap skill (${scope} scope):`);
+
+  for (const name of names) {
+    const cfg = PLATFORMS[name];
+    if (cfg.projectOnly && globalScope) {
+      console.log(`  skip ${cfg.label}: Cursor rule is project-scoped only (re-run with --project)`);
+      continue;
+    }
+    if (!existsSync(cfg.src)) throw new Error(`packaged skill missing: ${cfg.src}`);
+    const dest = cfg.dest(root);
+    const body = readFileSync(cfg.src, "utf8");
+    const versionFile = join(dirname(dest), ".agentmap_version");
+
+    if (dryRun) {
+      console.log(`  ${cfg.label}: ${dest}`);
+      continue;
+    }
+
+    atomicWrite(dest, body);
+    writeFileSync(versionFile, VERSION + "\n", "utf8");
+    console.log(`  ${cfg.label} → ${dest}`);
+    targets.push(dest);
+  }
+
+  if (!dryRun && targets.length) {
+    console.log(`\nagentmap --install-skill: installed ${targets.length} file(s) (${scope}).`);
+    if (!globalScope) gitAddHint(targets);
+    console.log("Pair with: agentmap --install-hooks (Claude Code) or agentmap --mcp (Cursor MCP).");
+  }
+}

--- a/skills/install.mjs
+++ b/skills/install.mjs
@@ -8,7 +8,6 @@ import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const SKILLS_DIR = dirname(fileURLToPath(import.meta.url));
-const VERSION = JSON.parse(readFileSync(join(SKILLS_DIR, "..", "package.json"), "utf8")).version;
 
 /** @type {Record<string, { label: string; src: string; dest: (root: string) => string; projectOnly?: boolean }>} */
 const PLATFORMS = {
@@ -58,6 +57,9 @@ function gitAddHint(paths) {
  */
 export function installSkill({ platforms: platformsArg = "all", project = true, global: globalScope = false, dryRun = false } = {}) {
   if (project && globalScope) throw new Error("use either --project or --global, not both");
+  // read version lazily (inside the function, not at module load) so importing
+  // this module is side-effect-free / off the CLI hot path.
+  const VERSION = JSON.parse(readFileSync(join(SKILLS_DIR, "..", "package.json"), "utf8")).version;
   const scope = globalScope ? "global" : "project";
   const root = globalScope ? homedir() : process.cwd();
   const names = parsePlatforms(platformsArg);

--- a/test/install-skill.test.mjs
+++ b/test/install-skill.test.mjs
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MIT
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { makeRepo, run, cleanup } from "./helpers.mjs";
+
+test("--install-skill installs project-scoped claude, cursor, agents files", () => {
+  const dir = makeRepo({ "src/index.ts": "export function x() { return 1; }" });
+  const r = run(dir, "--install-skill");
+  assert.equal(r.status, 0, r.stderr);
+
+  const claude = join(dir, ".claude", "skills", "agentmap", "SKILL.md");
+  const cursor = join(dir, ".cursor", "rules", "agentmap.mdc");
+  const agents = join(dir, ".agents", "skills", "agentmap", "SKILL.md");
+  assert.ok(existsSync(claude), "missing Claude SKILL.md");
+  assert.ok(existsSync(cursor), "missing Cursor rule");
+  assert.ok(existsSync(agents), "missing agents SKILL.md");
+  assert.match(readFileSync(claude, "utf8"), /name: agentmap/);
+  assert.match(readFileSync(cursor, "utf8"), /alwaysApply: true/);
+  assert.match(readFileSync(join(dir, ".claude", "skills", "agentmap", ".agentmap_version"), "utf8"), /0\.6\.0/);
+  cleanup(dir);
+});
+
+test("--install-skill --platform cursor --dry-run writes nothing", () => {
+  const dir = makeRepo({});
+  const r = run(dir, "--install-skill", "--platform", "cursor", "--dry-run");
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout, /--dry-run/);
+  assert.ok(!existsSync(join(dir, ".cursor", "rules", "agentmap.mdc")));
+  cleanup(dir);
+});
+
+test("--install-skill is idempotent", () => {
+  const dir = makeRepo({});
+  assert.equal(run(dir, "--install-skill", "--platform", "claude").status, 0);
+  assert.equal(run(dir, "--install-skill", "--platform", "claude").status, 0);
+  cleanup(dir);
+});

--- a/test/install-skill.test.mjs
+++ b/test/install-skill.test.mjs
@@ -5,6 +5,10 @@ import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { makeRepo, run, cleanup } from "./helpers.mjs";
 
+// derive the expected version from package.json (NOT hardcoded) so the test
+// survives version bumps / merges onto a newer main.
+const PKG_VERSION = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8")).version;
+
 test("--install-skill installs project-scoped claude, cursor, agents files", () => {
   const dir = makeRepo({ "src/index.ts": "export function x() { return 1; }" });
   const r = run(dir, "--install-skill");
@@ -18,7 +22,7 @@ test("--install-skill installs project-scoped claude, cursor, agents files", () 
   assert.ok(existsSync(agents), "missing agents SKILL.md");
   assert.match(readFileSync(claude, "utf8"), /name: agentmap/);
   assert.match(readFileSync(cursor, "utf8"), /alwaysApply: true/);
-  assert.match(readFileSync(join(dir, ".claude", "skills", "agentmap", ".agentmap_version"), "utf8"), /0\.6\.0/);
+  assert.equal(readFileSync(join(dir, ".claude", "skills", "agentmap", ".agentmap_version"), "utf8").trim(), PKG_VERSION);
   cleanup(dir);
 });
 


### PR DESCRIPTION
## Summary

Adds `--install-skill` so agents get persistent guidance on when and how to use agentmap before falling back to grep.

- **`--install-skill`** CLI flag with `--platform` (`claude`, `cursor`, `agents`, `all`), `--project` / `--global`, and `--dry-run`
- Ships **`skills/SKILL.md`** (Claude / agents skill) and **`skills/cursor-rule.mdc`** (Cursor always-on rule)
- **`skills/install.mjs`** handles atomic writes and version stamping
- Tests and README docs included

### Install destinations

| Platform | Path |
|----------|------|
| `claude` | `.claude/skills/agentmap/SKILL.md` (or `~/.claude/...` with `--global`) |
| `agents` | `.agents/skills/agentmap/SKILL.md` |
| `cursor` | `.cursor/rules/agentmap.mdc` (project only) |

### Usage

```bash
agentmap --install-skill                    # all platforms, project scope
agentmap --install-skill --platform cursor  # Cursor rule only
agentmap --install-skill --global --platform claude
agentmap --install-skill --dry-run
```

## Motivation

Without a skill or rule, coding agents default to grep even when `agentmap --find` or `--relates` would be faster and more precise. This copies packaged agent guidance into the standard skill/rule locations each platform already reads.

## Test plan

- [x] `npm test` — 127/127 pass (3 new install-skill tests)
- [ ] `agentmap --install-skill --dry-run` in a sample repo
- [ ] `agentmap --install-skill --platform cursor` and confirm `.cursor/rules/agentmap.mdc` is created
- [ ] Verify Cursor picks up the always-on rule in a real session