### PR TITLE
feat(install-skill): add Codex, OpenCode, Gemini, Antigravity, and Copilot CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to agentmap are documented here.
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Added
+- **`--install-skill` Tier B platforms** — `codex`, `opencode`, `gemini`, `antigravity`, `copilot` with paths aligned to OpenCode / Antigravity / Graphify conventions.
+
+### Changed
+- **`--platform all` default set** — now installs claude, cursor, codex, opencode, gemini, antigravity, copilot. Legacy `agents` is opt-in (`--platform agents`). Global `all` no longer writes `~/.agents/skills/` by default; use `antigravity` (graphify-aligned `~/.gemini/config/skills/`) or explicit `agents` for v0.7.0 `~/.agents/` behavior.
+
 ## [0.7.0] - 2026-06-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
-- **`--install-skill` Tier B platforms** — `codex`, `opencode`, `gemini`, `antigravity`, `copilot` with paths aligned to OpenCode / Antigravity / Graphify conventions.
+- **`--install-skill` platform expansion** — `codex`, `opencode`, `gemini`, `antigravity`, `copilot` with paths aligned to each platform's documented skill directories (OpenCode, Antigravity, etc.).
 
 ### Changed
-- **`--platform all` default set** — now installs claude, cursor, codex, opencode, gemini, antigravity, copilot. Legacy `agents` is opt-in (`--platform agents`). Global `all` no longer writes `~/.agents/skills/` by default; use `antigravity` (graphify-aligned `~/.gemini/config/skills/`) or explicit `agents` for v0.7.0 `~/.agents/` behavior.
+- **`--platform all` default set** — now installs claude, cursor, codex, opencode, gemini, antigravity, copilot. Legacy `agents` is opt-in (`--platform agents`). Global `all` no longer writes `~/.agents/skills/` by default; use `antigravity` (`~/.gemini/config/skills/`) or explicit `agents` for v0.7.0 `~/.agents/` behavior.
 
 ## [0.7.0] - 2026-06-15
 

--- a/README.md
+++ b/README.md
@@ -185,22 +185,30 @@ internally on `tool_name`. For reference, or to wire it by hand:
 That's the "forced to use it" in the tagline: the map stays current on its own, and the
 agent is steered to it the moment it reaches for a dependency-shaped grep or Bash search.
 
-### 3. Agent skills (Cursor, Claude Code, Codex)
+### 3. Agent skills (Cursor, Claude Code, Codex, OpenCode, Gemini, Antigravity, Copilot)
 
 ```bash
 npx @raymondchins/agentmap --install-skill
 ```
 
-Copies a packaged **SKILL.md** (Claude Code / Codex / OpenCode) and a **Cursor rule**
-(`.cursor/rules/agentmap.mdc`, `alwaysApply: true`) into the current repo or global
-agent directories. Options:
+Copies packaged **SKILL.md** files and a **Cursor rule** (`.cursor/rules/agentmap.mdc`,
+`alwaysApply: true`) into the current repo or global agent directories. Platform paths
+match [graphify](https://github.com/raymondchins/graphify) conventions. Options:
 
 ```bash
-agentmap --install-skill --platform cursor      # Cursor rule only
-agentmap --install-skill --platform claude      # .claude/skills/agentmap/SKILL.md
+agentmap --install-skill --platform cursor           # Cursor rule only (project)
+agentmap --install-skill --platform claude           # .claude/skills/agentmap/SKILL.md
+agentmap --install-skill --platform codex            # .codex/skills/ (project) or ~/.codex/skills/ (global)
+agentmap --install-skill --platform opencode         # .opencode/skills/ (project) or ~/.config/opencode/skills/ (global)
+agentmap --install-skill --platform gemini           # .gemini/skills/ (project); global ~/.gemini/skills/ (Windows global: ~/.agents/skills/)
+agentmap --install-skill --platform antigravity      # .agents/skills/ (project) or ~/.gemini/config/skills/ (global)
+agentmap --install-skill --platform copilot          # .copilot/skills/ or ~/.copilot/skills/
 agentmap --install-skill --global --platform claude  # ~/.claude/skills/...
-agentmap --install-skill --dry-run              # preview paths, no writes
+agentmap --install-skill --platform agents           # legacy .agents/skills/ (project or global); excluded from default `all`
+agentmap --install-skill --dry-run                   # preview paths, no writes
 ```
+
+`--platform all` installs: claude, cursor, codex, opencode, gemini, antigravity, copilot (not legacy `agents`).
 
 Pair with `--install-hooks` (Claude Code) or `--mcp` (Cursor MCP).
 
@@ -501,7 +509,7 @@ $ node agentmap.mjs --print | jq '.hubs[0]'
 | `--json` | **Global modifier.** When present, every command prints exactly one JSON object to stdout (no prose). Shapes vary per command: `--json --hubs` → `{command,fileCount,sha,hubs:[string]}`, `--json --find X` → `{command,query,matches:[{file,name,kind}]}`, `--json --relates X` → `{command,file,pagerank,exports,imports,dependents,related}`, `--json --any X` → `{command,query,kind,…payload}`, etc. Bare `--json` (no query flag) → `{command:"build",fileCount,features,topHub}`. |
 | `--install-hooks` | Copy `hooks/post-commit` into `.git/hooks/` (chmod 0755), ensure `.claude/agentmap.json` is in `.gitignore`, and auto-wire the Claude Code `PreToolUse(Grep)` nudge into `.claude/settings.json` (merge-safe + idempotent). Exit 0 on success, stderr + exit 1 on failure. |
 | `--hook-status` | Report whether the post-commit hook, PreToolUse nudge, and `.gitignore` entry are installed (no writes). |
-| `--install-skill` | Install packaged agent skill + Cursor rule (`--platform claude\|cursor\|agents\|all`, default `all`; `--project` default, or `--global`; `--dry-run` preview). |
+| `--install-skill` | Install packaged agent skill + Cursor rule (`--platform claude\|cursor\|codex\|opencode\|gemini\|antigravity\|copilot\|agents\|all`, default `all`; `--project` default, or `--global`; `--dry-run` preview). |
 | `--mcp` | Start agentmap as a **stdio MCP server** so non-Claude-Code agents (Cursor, Cline, any MCP client) can call every flag as a first-class tool. |
 
 **Exit-code contract:** `0` = success / match / help / version; `1` = query returned zero results (`--any`, `--find`, `--relates`, `--feature` with no match); `2` = usage error (missing required arg, unknown flag). Any token starting with `-` that matches no known flag prints an error to stderr and exits 2.

--- a/README.md
+++ b/README.md
@@ -192,8 +192,8 @@ npx @raymondchins/agentmap --install-skill
 ```
 
 Copies packaged **SKILL.md** files and a **Cursor rule** (`.cursor/rules/agentmap.mdc`,
-`alwaysApply: true`) into the current repo or global agent directories. Platform paths
-match [graphify](https://github.com/raymondchins/graphify) conventions. Options:
+`alwaysApply: true`) into the current repo or global agent directories. Paths follow
+each platform's official skill-directory conventions. Options:
 
 ```bash
 agentmap --install-skill --platform cursor           # Cursor rule only (project)

--- a/agentmap.mjs
+++ b/agentmap.mjs
@@ -1090,7 +1090,7 @@ Maintenance:
   --install-hooks [--dry-run]
                        install git post-commit + copy the PreToolUse nudge +
                        wire .claude/settings.json (--dry-run = preview, no writes)
-  --install-skill [--platform claude|cursor|agents|all] [--project|--global] [--dry-run]
+  --install-skill [--platform claude|cursor|codex|opencode|gemini|antigravity|copilot|agents|all] [--project|--global] [--dry-run]
                        install SKILL.md / Cursor rule for coding agents
   --hook-status          report whether agentmap git/nudge wiring is installed
   --setup-mcp [--dry-run]

--- a/skills/install.mjs
+++ b/skills/install.mjs
@@ -1,33 +1,81 @@
 // SPDX-License-Identifier: MIT
 // --install-skill: copy packaged SKILL.md / Cursor rule into project or global
 // agent directories (project or global scope).
+// Platform paths aligned with graphify _platform_skill_destination() (v0.8.39).
 
 import { readFileSync, writeFileSync, mkdirSync, existsSync, renameSync } from "node:fs";
-import { homedir } from "node:os";
+import { homedir, platform as osPlatform } from "node:os";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const SKILLS_DIR = dirname(fileURLToPath(import.meta.url));
+const SKILL_MD = join(SKILLS_DIR, "SKILL.md");
+const CURSOR_RULE = join(SKILLS_DIR, "cursor-rule.mdc");
 
-/** @type {Record<string, { label: string; src: string; dest: (root: string) => string; projectOnly?: boolean }>} */
+/** @param {string} root @param {boolean} globalScope */
+function skillPath(root, globalScope, ...segments) {
+  return join(root, ...segments);
+}
+
+/** @type {Record<string, { label: string; src: string; dest: (root: string, globalScope: boolean) => string; projectOnly?: boolean; legacy?: boolean }>} */
 const PLATFORMS = {
   claude: {
     label: "Claude Code",
-    src: join(SKILLS_DIR, "SKILL.md"),
-    dest: (root) => join(root, ".claude", "skills", "agentmap", "SKILL.md"),
-  },
-  agents: {
-    label: "Codex / OpenCode (.agents)",
-    src: join(SKILLS_DIR, "SKILL.md"),
-    dest: (root) => join(root, ".agents", "skills", "agentmap", "SKILL.md"),
+    src: SKILL_MD,
+    dest: (root) => skillPath(root, false, ".claude", "skills", "agentmap", "SKILL.md"),
   },
   cursor: {
     label: "Cursor",
-    src: join(SKILLS_DIR, "cursor-rule.mdc"),
-    dest: (root) => join(root, ".cursor", "rules", "agentmap.mdc"),
+    src: CURSOR_RULE,
+    dest: (root) => skillPath(root, false, ".cursor", "rules", "agentmap.mdc"),
     projectOnly: true,
   },
+  codex: {
+    label: "OpenAI Codex",
+    src: SKILL_MD,
+    dest: (root) => skillPath(root, false, ".codex", "skills", "agentmap", "SKILL.md"),
+  },
+  opencode: {
+    label: "OpenCode",
+    src: SKILL_MD,
+    // Project: .opencode/skills/ (repo). Global: ~/.config/opencode/skills/ (not .config in repo).
+    dest: (root, globalScope) =>
+      globalScope
+        ? join(root, ".config", "opencode", "skills", "agentmap", "SKILL.md")
+        : join(root, ".opencode", "skills", "agentmap", "SKILL.md"),
+  },
+  gemini: {
+    label: "Gemini CLI",
+    src: SKILL_MD,
+    dest: (root, globalScope) => {
+      if (!globalScope) return skillPath(root, false, ".gemini", "skills", "agentmap", "SKILL.md");
+      if (osPlatform() === "win32") return skillPath(root, true, ".agents", "skills", "agentmap", "SKILL.md");
+      return skillPath(root, true, ".gemini", "skills", "agentmap", "SKILL.md");
+    },
+  },
+  antigravity: {
+    label: "Antigravity",
+    src: SKILL_MD,
+    dest: (root, globalScope) =>
+      globalScope
+        ? skillPath(root, true, ".gemini", "config", "skills", "agentmap", "SKILL.md")
+        : skillPath(root, false, ".agents", "skills", "agentmap", "SKILL.md"),
+  },
+  agents: {
+    label: "Amp / legacy .agents",
+    src: SKILL_MD,
+    dest: (root) => skillPath(root, false, ".agents", "skills", "agentmap", "SKILL.md"),
+    legacy: true,
+  },
+  copilot: {
+    label: "GitHub Copilot CLI",
+    src: SKILL_MD,
+    dest: (root) => skillPath(root, false, ".copilot", "skills", "agentmap", "SKILL.md"),
+  },
 };
+
+/** Default --platform all: Tier B + core; excludes legacy `agents` (use antigravity for graphify-aligned global). */
+const DEFAULT_PLATFORMS = ["claude", "cursor", "codex", "opencode", "gemini", "antigravity", "copilot"];
 
 function atomicWrite(dest, body) {
   mkdirSync(dirname(dest), { recursive: true });
@@ -37,14 +85,22 @@ function atomicWrite(dest, body) {
 }
 
 function parsePlatforms(raw) {
-  if (!raw || raw === "all") return ["claude", "cursor", "agents"];
-  const names = raw.split(/[,+]/).map((s) => s.trim().toLowerCase()).filter(Boolean);
-  for (const n of names) {
+  const keys = Object.keys(PLATFORMS).join(", ");
+  if (!raw || raw === "all") return [...DEFAULT_PLATFORMS];
+  const tokens = raw.split(/[,+]/).map((s) => s.trim().toLowerCase()).filter(Boolean);
+  if (tokens.includes("all")) {
+    const extra = tokens.filter((t) => t !== "all");
+    for (const n of extra) {
+      if (!PLATFORMS[n]) throw new Error(`unknown platform '${n}' — choose: ${keys}, all`);
+    }
+    return [...new Set([...DEFAULT_PLATFORMS, ...extra])];
+  }
+  for (const n of tokens) {
     if (!PLATFORMS[n]) {
-      throw new Error(`unknown platform '${n}' — choose: ${Object.keys(PLATFORMS).join(", ")}, all`);
+      throw new Error(`unknown platform '${n}' — choose: ${keys}, all`);
     }
   }
-  return names;
+  return tokens;
 }
 
 function gitAddHint(paths) {
@@ -57,13 +113,12 @@ function gitAddHint(paths) {
  */
 export function installSkill({ platforms: platformsArg = "all", project = true, global: globalScope = false, dryRun = false } = {}) {
   if (project && globalScope) throw new Error("use either --project or --global, not both");
-  // read version lazily (inside the function, not at module load) so importing
-  // this module is side-effect-free / off the CLI hot path.
   const VERSION = JSON.parse(readFileSync(join(SKILLS_DIR, "..", "package.json"), "utf8")).version;
   const scope = globalScope ? "global" : "project";
   const root = globalScope ? homedir() : process.cwd();
   const names = parsePlatforms(platformsArg);
   const targets = [];
+  const seenDest = new Set();
 
   if (dryRun) console.log(`--dry-run: would install agentmap skill (${scope} scope):`);
 
@@ -74,7 +129,12 @@ export function installSkill({ platforms: platformsArg = "all", project = true, 
       continue;
     }
     if (!existsSync(cfg.src)) throw new Error(`packaged skill missing: ${cfg.src}`);
-    const dest = cfg.dest(root);
+    const dest = cfg.dest(root, globalScope);
+    if (seenDest.has(dest)) {
+      console.log(`  skip ${cfg.label}: same path as another platform (${dest})`);
+      continue;
+    }
+    seenDest.add(dest);
     const body = readFileSync(cfg.src, "utf8");
     const versionFile = join(dirname(dest), ".agentmap_version");
 

--- a/skills/install.mjs
+++ b/skills/install.mjs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // --install-skill: copy packaged SKILL.md / Cursor rule into project or global
 // agent directories (project or global scope).
-// Platform paths aligned with graphify _platform_skill_destination() (v0.8.39).
+// Platform paths follow each agent's documented skill directories.
 
 import { readFileSync, writeFileSync, mkdirSync, existsSync, renameSync } from "node:fs";
 import { homedir, platform as osPlatform } from "node:os";
@@ -74,7 +74,7 @@ const PLATFORMS = {
   },
 };
 
-/** Default --platform all: Tier B + core; excludes legacy `agents` (use antigravity for graphify-aligned global). */
+/** Default --platform all: core + new platforms; excludes legacy `agents`. */
 const DEFAULT_PLATFORMS = ["claude", "cursor", "codex", "opencode", "gemini", "antigravity", "copilot"];
 
 function atomicWrite(dest, body) {

--- a/test/install-skill.test.mjs
+++ b/test/install-skill.test.mjs
@@ -5,24 +5,62 @@ import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { makeRepo, run, cleanup } from "./helpers.mjs";
 
-// derive the expected version from package.json (NOT hardcoded) so the test
-// survives version bumps / merges onto a newer main.
 const PKG_VERSION = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8")).version;
 
-test("--install-skill installs project-scoped claude, cursor, agents files", () => {
+test("--install-skill installs project-scoped claude, cursor, antigravity files (default all)", () => {
   const dir = makeRepo({ "src/index.ts": "export function x() { return 1; }" });
   const r = run(dir, "--install-skill");
   assert.equal(r.status, 0, r.stderr);
 
   const claude = join(dir, ".claude", "skills", "agentmap", "SKILL.md");
   const cursor = join(dir, ".cursor", "rules", "agentmap.mdc");
-  const agents = join(dir, ".agents", "skills", "agentmap", "SKILL.md");
+  const antigravity = join(dir, ".agents", "skills", "agentmap", "SKILL.md");
+  const codex = join(dir, ".codex", "skills", "agentmap", "SKILL.md");
+  const opencode = join(dir, ".opencode", "skills", "agentmap", "SKILL.md");
   assert.ok(existsSync(claude), "missing Claude SKILL.md");
   assert.ok(existsSync(cursor), "missing Cursor rule");
-  assert.ok(existsSync(agents), "missing agents SKILL.md");
+  assert.ok(existsSync(antigravity), "missing antigravity SKILL.md");
+  assert.ok(existsSync(codex), "missing codex SKILL.md");
+  assert.ok(existsSync(opencode), "missing opencode SKILL.md");
+  assert.ok(existsSync(join(dir, ".gemini", "skills", "agentmap", "SKILL.md")), "missing gemini SKILL.md");
+  assert.ok(existsSync(join(dir, ".copilot", "skills", "agentmap", "SKILL.md")), "missing copilot SKILL.md");
   assert.match(readFileSync(claude, "utf8"), /name: agentmap/);
   assert.match(readFileSync(cursor, "utf8"), /alwaysApply: true/);
   assert.equal(readFileSync(join(dir, ".claude", "skills", "agentmap", ".agentmap_version"), "utf8").trim(), PKG_VERSION);
+  cleanup(dir);
+});
+
+test("--install-skill --platform agents still installs legacy .agents path", () => {
+  const dir = makeRepo({});
+  const r = run(dir, "--install-skill", "--platform", "agents");
+  assert.equal(r.status, 0, r.stderr);
+  assert.ok(existsSync(join(dir, ".agents", "skills", "agentmap", "SKILL.md")));
+  cleanup(dir);
+});
+
+test("--install-skill --platform opencode uses .opencode/skills project path", () => {
+  const dir = makeRepo({});
+  const r = run(dir, "--install-skill", "--platform", "opencode");
+  assert.equal(r.status, 0, r.stderr);
+  assert.ok(existsSync(join(dir, ".opencode", "skills", "agentmap", "SKILL.md")));
+  assert.ok(!existsSync(join(dir, ".config", "opencode", "skills", "agentmap", "SKILL.md")));
+  cleanup(dir);
+});
+
+test("--install-skill --global --platform antigravity --dry-run targets ~/.gemini/config/skills", () => {
+  const dir = makeRepo({});
+  const r = run(dir, "--install-skill", "--global", "--platform", "antigravity", "--dry-run");
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout, /\.gemini[/\\]config[/\\]skills[/\\]agentmap[/\\]SKILL\.md/);
+  cleanup(dir);
+});
+
+test("--install-skill --global --platform opencode --dry-run targets ~/.config/opencode/skills", () => {
+  const dir = makeRepo({});
+  const r = run(dir, "--install-skill", "--global", "--platform", "opencode", "--dry-run");
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout, /\.config[/\\]opencode[/\\]skills[/\\]agentmap[/\\]SKILL\.md/);
+  assert.doesNotMatch(r.stdout, /\.opencode[/\\]skills[/\\]agentmap/);
   cleanup(dir);
 });
 
@@ -32,6 +70,22 @@ test("--install-skill --platform cursor --dry-run writes nothing", () => {
   assert.equal(r.status, 0, r.stderr);
   assert.match(r.stdout, /--dry-run/);
   assert.ok(!existsSync(join(dir, ".cursor", "rules", "agentmap.mdc")));
+  cleanup(dir);
+});
+
+test("--install-skill --platform all,agents expands and dedupes", () => {
+  const dir = makeRepo({});
+  const r = run(dir, "--install-skill", "--platform", "all,agents", "--dry-run");
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout, /skip.*legacy.*same path/s);
+  cleanup(dir);
+});
+
+test("--install-skill unknown platform fails", () => {
+  const dir = makeRepo({});
+  const r = run(dir, "--install-skill", "--platform", "notaplatform");
+  assert.notEqual(r.status, 0);
+  assert.match(r.stderr, /unknown platform/);
   cleanup(dir);
 });
 


### PR DESCRIPTION
## Summary

Extends `agentmap --install-skill` (shipped in v0.7.0 with Claude Code, Cursor, and legacy `agents`) to five additional **common agent CLIs**: **Codex**, **OpenCode**, **Gemini CLI**, **Antigravity**, and **GitHub Copilot CLI**.

This PR is **skill-file only**: it copies the packaged `SKILL.md` (or Cursor `.mdc` rule) to each platform's canonical skill directory. It does **not** add hooks, `AGENTS.md` / `GEMINI.md` sections, OpenCode plugins, or other always-on wiring (those stay separate follow-ups, e.g. `--install-hooks` for Claude).

Platform paths follow each agent's official documentation (e.g. OpenCode skills docs, Antigravity skills docs).

### Platforms after this PR

| `--platform` | Project path | Global path (`--global`) |
|--------------|--------------|---------------------------|
| `claude` | `.claude/skills/agentmap/SKILL.md` | `~/.claude/skills/agentmap/SKILL.md` |
| `cursor` | `.cursor/rules/agentmap.mdc` | *(project only)* |
| `codex` | `.codex/skills/agentmap/SKILL.md` | `~/.codex/skills/agentmap/SKILL.md` |
| `opencode` | `.opencode/skills/agentmap/SKILL.md` | `~/.config/opencode/skills/agentmap/SKILL.md` |
| `gemini` | `.gemini/skills/agentmap/SKILL.md` | `~/.gemini/skills/agentmap/SKILL.md` (Windows global: `~/.agents/skills/`) |
| `antigravity` | `.agents/skills/agentmap/SKILL.md` | `~/.gemini/config/skills/agentmap/SKILL.md` |
| `copilot` | `.copilot/skills/agentmap/SKILL.md` | `~/.copilot/skills/agentmap/SKILL.md` |
| `agents` | `.agents/skills/agentmap/SKILL.md` | `~/.agents/skills/agentmap/SKILL.md` *(legacy v0.7.0 compat; opt-in)* |

### Breaking change: `--platform all`

v0.7.0 `all` installed `claude`, `cursor`, and `agents` (global `all` wrote `~/.agents/skills/`).

New default `all` installs: `claude`, `cursor`, `codex`, `opencode`, `gemini`, `antigravity`, `copilot`.

- Legacy `agents` is **excluded** from `all` — pass `--platform agents` explicitly for v0.7.0 `~/.agents/` global behavior.
- Global `all` now uses `antigravity` → `~/.gemini/config/skills/` instead of `agents` → `~/.agents/skills/`.

Documented in `CHANGELOG.md` under `[Unreleased]`. Recommend shipping as **0.8.0**.

### Other behavior

- `parsePlatforms('all,agents')` expands `all` and merges extra platforms (with dedup when paths collide).
- Duplicate destination paths log a skip message (dry-run and real install).
- CLI help and README updated; 9 install-skill tests (140 total).

## Test plan

- [x] `npm test` — 140 tests pass
- [x] `agentmap --install-skill` — project installs for all platforms in default `all`
- [x] `agentmap --install-skill --platform agents` — legacy `.agents` path unchanged
- [x] `agentmap --install-skill --platform opencode` — `.opencode/skills/` (not `.config/opencode/` in repo)
- [x] `agentmap --install-skill --global --platform opencode --dry-run` — `~/.config/opencode/skills/`
- [x] `agentmap --install-skill --global --platform antigravity --dry-run` — `~/.gemini/config/skills/`
- [x] `agentmap --install-skill --platform all,agents --dry-run` — expands and dedupes
- [x] Unknown `--platform` — clear error
- [x] Idempotent re-run

## Out of scope (follow-up PRs)

- Hooks / always-on docs (`GEMINI.md`, `AGENTS.md`, OpenCode plugin parity)
- `install-skill` uninstall
- Niche platforms (Aider, Amp, Trae, Pi, Kimi, Devin, etc.)
