### PR TITLE
security: least-privilege CI token + lockfile version sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ on:
   push:
   pull_request:
 
+# Least privilege by default: jobs get a read-only GITHUB_TOKEN. The codeql job
+# re-declares the extra scopes it needs (security-events: write), overriding this.
+permissions:
+  contents: read
+
 jobs:
   test:
     name: test (node ${{ matrix.node-version }})

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,10 @@ on:
     tags:
       - "v*"
 
+# Read-only default; the publish job re-declares the write scopes it needs below.
+permissions:
+  contents: read
+
 jobs:
   publish:
     name: Publish to npm

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@raymondchins/agentmap",
-  "version": "0.11.0",
+  "version": "0.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@raymondchins/agentmap",
-      "version": "0.11.0",
+      "version": "0.12.1",
       "license": "MIT",
       "dependencies": {
         "ts-morph": "28.0.0"


### PR DESCRIPTION
Refs #29

## Summary

Applies the safe, non-breaking fixes from the security scan in #29. No dependency CVEs or code-level vulnerabilities were found; these are CI/supply-chain hardening items.

## Changes

| Change | Vulnerability addressed | Severity |
|--------|------------------------|----------|
| `ci.yml`: add top-level `permissions: contents: read` | Over-privileged default `GITHUB_TOKEN` on `push`/`pull_request` (incl. fork PRs) running project code. OpenSSF Scorecard *Token-Permissions*. | Medium |
| `publish.yml`: add top-level `permissions: contents: read` | No least-privilege default; future jobs would inherit repo default. Defense-in-depth. | Low |
| `package-lock.json`: sync root `version` 0.11.0 → 0.12.1 | Lockfile drift vs `package.json` (supply-chain hygiene). | Low |

The `codeql` job (in `ci.yml`) and the `publish` job (in `publish.yml`) keep their own explicit `permissions:` blocks, which override the new read-only default where write scopes are genuinely needed — so CodeQL upload, the GitHub Release, and npm OIDC provenance are unaffected.

## Testing

- `npm ci` — clean, `found 0 vulnerabilities`.
- `npm audit` — 0 vulnerabilities.
- `node agentmap.mjs --hubs` smoke test — passes (exit 0).
- Note: the full `npm test` suite could not be run in this environment (the `test/` directory was not present in the provided sparse worktree). CI on this PR will run the complete suite.
- YAML changes are additive top-level keys; job-level `permissions:` blocks are unchanged.

## Remaining items needing human review

None requiring breaking changes or major version bumps. See #29 for the full findings and the list of already-strong existing controls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)