### PR TITLE
chore(ci): green the build — bump codeql-action + clear brace-expansion advisory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,13 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "chore(ci)"
+    # codeql-action/init and codeql-action/analyze must run at the same version
+    # or CodeQL fails with a configuration error. Bundle them into one PR so a
+    # bump never lands on only one of the pair.
+    groups:
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"
   - package-ecosystem: "npm"
     directory: "/"
     schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,12 +62,12 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           languages: javascript-typescript
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
 
   secret-scan:
     name: Secret scan (Gitleaks)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@raymondchins/agentmap",
-  "version": "0.11.0",
+  "version": "0.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@raymondchins/agentmap",
-      "version": "0.11.0",
+      "version": "0.15.1",
       "license": "MIT",
       "dependencies": {
         "ts-morph": "28.0.0"
@@ -39,9 +39,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"


### PR DESCRIPTION
## What & why

Two changes that together get CI back to green on `main`:

**1. CodeQL version mismatch (fixes #34, #35)**
Bumps both `github/codeql-action/init` and `github/codeql-action/analyze` from v4.37.0 to v4.37.1 in a **single** commit. Dependabot split this into two separate PRs (#34 `init`, #35 `analyze`); each failed CI on its own because CodeQL requires `init` and `analyze` at the **same** version — bumping only one produces `CodeQL job status was configuration error`. `.github/dependabot.yml` now groups `github/codeql-action*` so this can't split again; Dependabot will auto-close #34/#35 once this merges.

**2. brace-expansion audit failure (GHSA-3jxr-9vmj-r5cp)**
A high-severity advisory (DoS via exponential-time brace expansion) landed for `brace-expansion`, which reaches the tree transitively via `ts-morph → @ts-morph/common → minimatch`. The test job's `npm audit --audit-level=high` step now fails on `main`, so every test matrix leg is red — unrelated to the CodeQL change but blocking any green build. `npm audit fix` bumps the pinned version to the patched `5.0.7` in the lockfile only (no direct-dependency change) and clears the advisory.

Changes:
- `.github/workflows/ci.yml`: `init` + `analyze` → `7188fc3` (v4.37.1)
- `.github/dependabot.yml`: add `codeql-action` group
- `package-lock.json`: `brace-expansion` 5.0.6 → 5.0.7 (+ sync stale lockfile version field)

## Checklist

- [x] `node --test test/` passes locally (Node 18+). — 356/356 pass.
- [x] No new runtime dependency (ts-morph stays the only one). — transitive lockfile bump only.
- [x] Still a single published artifact (`agentmap.mjs`, `#!/usr/bin/env node` shebang intact).
- [x] Freshness invariant intact — no cache/freshness logic touched.
- [x] If `map.json` shape changed: `SCHEMA_VERSION` bumped. — n/a, no schema change.
- [x] Output of shipped commands is byte-identical — no CLI output affected.
- [x] Docs / CHANGELOG updated if user-facing. — n/a, CI/tooling only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)