### PR TITLE
fix(deps): bump brace-expansion to 5.0.8 for GHSA-mh99-v99m-4gvg

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,15 +39,15 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/code-block-writer": {


### PR DESCRIPTION
## What & why

A **second** `brace-expansion` advisory landed, distinct from the one cleared in #36: [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg) (DoS via unbounded expansion length causing an out-of-memory crash) affects `<=5.0.7` — so the `5.0.7` pin that fixed GHSA-3jxr-9vmj-r5cp is itself now flagged.

The package reaches the tree transitively via `ts-morph → @ts-morph/common → minimatch`, so CI's `npm audit --audit-level=high` step fails again on `main`, reddening every test matrix leg.

`npm audit fix` moves the pin to the patched `5.0.8` in the lockfile only — no direct dependency change (`ts-morph` stays the sole runtime dep).

Verified locally: `npm audit` reports **0 vulnerabilities**, all **356 tests pass**.

## Checklist

- [x] `node --test test/` passes locally (Node 18+). — 356/356 pass.
- [x] No new runtime dependency (ts-morph stays the only one). — transitive lockfile bump only.
- [x] Still a single published artifact (`agentmap.mjs`, `#!/usr/bin/env node` shebang intact).
- [x] Freshness invariant intact — no cache/freshness logic touched.
- [x] If `map.json` shape changed: `SCHEMA_VERSION` bumped. — n/a, no schema change.
- [x] Output of shipped commands is byte-identical — no CLI output affected.
- [x] Docs / CHANGELOG updated if user-facing. — n/a, dependency hygiene only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QToCLNU4rAYgf79Y7HTfUo)_