### PR TITLE
fix(release): stop MCP Registry hiccups from failing the release run

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -79,10 +79,19 @@ jobs:
       # id-token: write permission above) authorizes the io.github.raymondchins/*
       # namespace — no secret needed. Runs LAST so a registry hiccup never blocks
       # the npm publish or the GitHub Release.
+      #
+      # continue-on-error is what actually delivers that "never blocks" promise:
+      # ordering alone still fails the job (and so the whole release run) when the
+      # registry is down, even though npm publish and the Release already landed.
+      # Re-running to clear the red would then hit EPUBLISHCONFLICT on npm publish.
+      # -f makes curl fail loudly on an HTTP error instead of piping an HTML error
+      # page into tar, which would otherwise surface as "not in gzip format".
       - name: Install mcp-publisher
-        run: curl -sL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" | tar xz mcp-publisher
+        continue-on-error: true
+        run: curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" | tar xz mcp-publisher
 
       - name: Publish to the MCP Registry (GitHub OIDC — no secret)
+        continue-on-error: true
         run: |
           ./mcp-publisher login github-oidc
           ./mcp-publisher publish ./server.json


### PR DESCRIPTION
## What & why

Found while auditing for latent CI failures. `publish.yml` is the one workflow CI never exercises — it only fires on a version tag — so a defect there stays invisible until release day.

**The bug:** the two MCP Registry steps are ordered last, with a comment stating a registry hiccup "never blocks the npm publish or the GitHub Release." Ordering alone doesn't deliver that. If either step fails, the **job** fails, so the whole Publish run goes red even though `npm publish` and the GitHub Release already succeeded. Worse, re-running to clear the red would hit `EPUBLISHCONFLICT` on `npm publish` — that version is already on the registry.

`continue-on-error: true` on both steps makes the comment's promise actually hold. Every gate that must stay blocking — tag/version check, tests, smoke, pack manifest, npm publish, GitHub Release — is untouched.

Also switches `curl -sL` → `-fsSL` for the mcp-publisher download. Without `-f`, curl exits 0 on an HTTP error and pipes the error page into `tar`, which then fails with a confusing `not in gzip format` instead of naming the real problem.

Verified: all three YAML files parse, and only those two steps carry `continue-on-error`.

## Checklist

- [x] `node --test test/` passes locally (Node 18+). — workflow-only change; suite green on this base (356/356).
- [x] No new runtime dependency (ts-morph stays the only one).
- [x] Still a single published artifact (`agentmap.mjs`, `#!/usr/bin/env node` shebang intact).
- [x] Freshness invariant intact — no cache/freshness logic touched.
- [x] If `map.json` shape changed: `SCHEMA_VERSION` bumped. — n/a, no schema change.
- [x] Output of shipped commands is byte-identical — no CLI output affected.
- [x] Docs / CHANGELOG updated if user-facing. — n/a, release plumbing only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QToCLNU4rAYgf79Y7HTfUo)_