### PR TITLE
ci: halve PR runs, isolate the audit gate, and pin the mcp-publisher download

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,11 @@ on:
   push:
     branches: [main]
   pull_request:
+  # Daily sweep purely for the audit job below. `npm audit` queries the registry
+  # advisory DB live, so a newly published advisory is invisible until something
+  # runs — without this, a quiet week leaves main silently unaudited.
+  schedule:
+    - cron: "17 6 * * *"
 
 # Least privilege by default: jobs get a read-only GITHUB_TOKEN. Jobs that need
 # more (codeql re-declares security-events + actions below) override this.
@@ -19,6 +24,9 @@ permissions:
 jobs:
   test:
     name: test (node ${{ matrix.node-version }})
+    # The schedule trigger exists only to re-run `audit` against a moving
+    # advisory DB; the code is unchanged between crons, so skip the rest.
+    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -47,16 +55,43 @@ jobs:
       - name: Smoke (--hubs on self)
         run: node agentmap.mjs --hubs
 
-      # Audit for high-severity vulnerabilities in the dependency tree.
-      - name: Audit dependencies
-        run: npm audit --audit-level=high
-
       # Validate the published file set without actually packing.
       - name: Validate pack manifest
         run: npm pack --dry-run
 
+  # Audit for high-severity vulnerabilities in the dependency tree. Deliberately
+  # its own job rather than a step in the matrix above: it depends only on the
+  # lockfile, so running it per Node version was three identical checks, and a
+  # failure there also skipped the pack-manifest step behind it.
+  audit:
+    name: Audit dependencies
+    # Not on pull_request. `npm audit` resolves advisories live, so a third-party
+    # advisory published mid-review reddens PRs that never touched dependencies —
+    # this fired twice in four days over a transitive brace-expansion pulled in by
+    # ts-morph, blocking unrelated work both times. Pushes to main and the daily
+    # cron still fail loudly, which is where the signal is actually actionable.
+    # Trade-off accepted: a PR that *introduces* a vulnerable dep is caught on
+    # merge rather than pre-merge.
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Audit dependencies
+        run: npm audit --audit-level=high
+
   codeql:
     name: CodeQL analysis
+    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     permissions:
       security-events: write
@@ -76,6 +111,7 @@ jobs:
 
   secret-scan:
     name: Secret scan (Gitleaks)
+    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,14 @@
 name: CI
 
-# Run on every push and PR. The README badge resolves against this exact file
-# name (.github/workflows/ci.yml), so do not rename it.
+# Runs on pushes to main and on every PR. `push:` is filtered to main on
+# purpose: unfiltered, a same-repo PR branch fires BOTH push and pull_request,
+# running all three jobs twice per commit. The README badge is unaffected — it
+# pins neither branch nor event, so it resolves the latest run on the default
+# branch, which pushes to main still produce. The badge does resolve against
+# this exact file name (.github/workflows/ci.yml), so do not rename it.
 on:
   push:
+    branches: [main]
   pull_request:
 
 # Least privilege by default: jobs get a read-only GITHUB_TOKEN. Jobs that need

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -86,9 +86,27 @@ jobs:
       # Re-running to clear the red would then hit EPUBLISHCONFLICT on npm publish.
       # -f makes curl fail loudly on an HTTP error instead of piping an HTML error
       # page into tar, which would otherwise surface as "not in gzip format".
+      # Pinned + checksum-verified, to match the SHA-pinning policy every `uses:`
+      # in this repo follows. `releases/latest` was the one unpinned executable in
+      # either workflow, fetched and run with id-token: write in scope. A release
+      # *tag* is mutable — assets can be re-uploaded under it — so the sha256 is
+      # what actually pins the bytes; the tag alone would not reach parity.
+      # Dependabot cannot see URLs inside a `run:` block, so bump VERSION and
+      # SHA256 together by hand from the checksums asset
+      # (registry_<version>_checksums.txt) at
+      # https://github.com/modelcontextprotocol/registry/releases
       - name: Install mcp-publisher
         continue-on-error: true
-        run: curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" | tar xz mcp-publisher
+        env:
+          MCP_PUBLISHER_VERSION: v1.8.0
+          MCP_PUBLISHER_SHA256: 1370446bbe74d562608e8005a6ccce02d146a661fbd78674e11cc70b9618d6cf
+        run: |
+          set -euo pipefail
+          curl -fsSL -o mcp-publisher.tar.gz \
+            "https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/mcp-publisher_linux_amd64.tar.gz"
+          echo "${MCP_PUBLISHER_SHA256}  mcp-publisher.tar.gz" | sha256sum -c -
+          tar xzf mcp-publisher.tar.gz mcp-publisher
+          rm -f mcp-publisher.tar.gz
 
       - name: Publish to the MCP Registry (GitHub OIDC — no secret)
         continue-on-error: true


### PR DESCRIPTION
## What & why

Three independent CI/release hygiene fixes from the audit, one commit each.

**1. `ci: fire push builds only on main` — halves CI usage**
`on: push:` was unfiltered, so a same-repo PR branch fired *both* `push` and `pull_request` for the same commit — running `test` (×3 Node versions), `codeql` and `secret-scan` twice per push. Every Dependabot PR paid double. Filtering `push` to `main` leaves exactly one run per PR commit and one per merge. The README badge pins neither branch nor event, so it still resolves the latest run on the default branch. `publish.yml` is a separate, already tag-filtered file.

*Trade-off:* pushing a branch without opening a PR no longer triggers CI. `CONTRIBUTING.md` already directs contributors to run `npm test` locally and verify through a PR, so nothing documented depends on it.

**2. `ci: move npm audit into its own job` — stops unrelated PRs going red**
`npm audit` was a step inside the test matrix, so any high-severity advisory in the transitive tree reddened all three Node legs. That fired **twice in four days** over `brace-expansion` (reached via `ts-morph → @ts-morph/common → minimatch`), blocking PRs that never touched dependencies. It also ran three identical checks against one lockfile, and a failure skipped the pack-manifest step behind it.

Now a dedicated `audit` job that skips `pull_request`. Pushes to `main` and a **new daily cron** still fail loudly, and the failing check reads `Audit dependencies` rather than `test (node 20)`. The cron is new capability: `npm audit` resolves advisories live, so previously an advisory published during a quiet week went unnoticed until someone happened to push. `test`/`codeql`/`secret-scan` are gated off the schedule trigger.

*Trade-off:* a PR that *introduces* a vulnerable dep is caught on merge rather than pre-merge. With one direct dependency, transitive drift was always the real source here and can't be pre-empted at review time.

**3. `ci(release): pin and checksum-verify mcp-publisher`**
Every `uses:` in both workflows is SHA-pinned, with `dependabot.yml` stating that's for supply-chain safety. The mcp-publisher install contradicted it: it curled `releases/latest` — a moving target — and executed the result in a job holding `id-token: write`. It was the only unpinned executable in either workflow.

Pinned to `v1.8.0` with sha256 verification before extraction. The **checksum**, not the tag, is what pins the bytes — git tags are mutable and release assets can be re-uploaded, so a version pin alone wouldn't reach parity. Hash confirmed against the published `registry_1.8.0_checksums.txt` *and* a locally computed `sha256sum` of the downloaded artifact. Both paths tested under `bash -e`: correct hash extracts and exits 0; tampered hash fails with nothing extracted. `continue-on-error` is retained, so a stale pin degrades to a skipped registry listing.

### Verified
Job gating simulated from the parsed YAML:

| Event | Jobs that run |
|---|---|
| `pull_request` | test, codeql, secret-scan |
| `push` (main) | test, **audit**, codeql, secret-scan |
| `schedule` | **audit** only |

All three workflow/config YAML files parse. `npm audit` → 0 vulnerabilities.

## Checklist

- [x] `node --test test/` passes locally (Node 18+). — 356/356 on this tree; no source touched.
- [x] No new runtime dependency (ts-morph stays the only one).
- [x] Still a single published artifact (`agentmap.mjs`, `#!/usr/bin/env node` shebang intact).
- [x] Freshness invariant intact — no cache/freshness logic touched.
- [x] If `map.json` shape changed: `SCHEMA_VERSION` bumped. — n/a, no schema change.
- [x] Output of shipped commands is byte-identical — no CLI output affected.
- [x] Docs / CHANGELOG updated if user-facing. — n/a, CI/release plumbing only.

## Not included — needs your call

**Node 18 (`ROADMAP.md:440` already tracks this).** Investigated but deliberately not changed: bumping `engines` is a breaking change for published consumers and belongs to a version decision, not a CI PR.

Finding: agentmap's own code is **clean** on Node 18 — zero Node-19+ features, no `import.meta.dirname`, and `test/vue-sfc/fixtures.mjs:14-18` shows the 18 compat is deliberately maintained. But the **dependency tree already excludes 18**: `brace-expansion@5.0.8` declares `engines: "20 || >=22"`, introduced by the security bump in #39. So `>=18` is already untrue in aggregate — pnpm users and anyone with `engine-strict=true` can't install today.

Note `>=20` is *also* EOL (April 2026), so it aligns the tree but doesn't deliver EOL hygiene; only `>=22` does, at a larger break. Suggested landing: `0.16.0` (0.MINOR is the breaking slot pre-1.0), touching `package.json:34`, `ci.yml` matrix, and five doc sites (`README.md:24`, `CONTRIBUTING.md:114,123`, `hooks/INSTALL.md:22`, `ROADMAP.md:460`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QToCLNU4rAYgf79Y7HTfUo)_