### PR TITLE
feat!: raise minimum Node to 20 and retarget the CI matrix

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,7 +13,7 @@ body:
     id: node
     attributes:
       label: Node version
-      description: "node --version (must be >=18)"
+      description: "node --version (must be >=20)"
     validations:
       required: true
   - type: dropdown

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@
 
 ## Checklist
 
-- [ ] `node --test test/` passes locally (Node 18+).
+- [ ] `node --test test/` passes locally (Node 20+).
 - [ ] No new runtime dependency (ts-morph stays the only one).
 - [ ] Still a single published artifact (`agentmap.mjs`, `#!/usr/bin/env node` shebang intact).
 - [ ] Freshness invariant intact — the cache is never served on a dirty tree / SHA mismatch; no "skip freshness" flag added.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18, 20, 22]
+        node-version: [20, 22, 24]
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+- **Minimum Node is now 20** (`engines` was `>=18`). This is a breaking change for
+  anyone still installing on Node 18. The floor is set by the dependency tree, not
+  by EOL dates: `brace-expansion` — pulled in transitively via `ts-morph` →
+  `@ts-morph/common` → `minimatch`, and bumped to 5.0.8 for GHSA-mh99-v99m-4gvg —
+  declares `20 || >=22`, so `>=18` was a claim the installed tree contradicted.
+  npm only warns on a transitive `engines` mismatch, but pnpm and anyone running
+  `engine-strict=true` got a hard install failure on Node 18. agentmap's own code
+  uses nothing above Node 18; this is purely about telling the truth.
+- **CI matrix is now `[20, 22, 24]`** (was `[18, 20, 22]`) — the new floor, current
+  LTS, and forward coverage, at the same three-leg cost.
+
 ## [0.15.1] - 2026-07-19
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,7 +111,7 @@ When you touch caching, building, or the schema:
 
 ## Style
 
-- Plain ES modules, Node 18+, no build step. The published artifact is the
+- Plain ES modules, Node 20+, no build step. The published artifact is the
   single `agentmap.mjs` file (keep the `#!/usr/bin/env node` shebang at the top).
 - Determinism matters: ranking must not depend on a PRNG or unstable iteration
   order. PageRank uses a fixed node order and converges by tolerance.
@@ -120,7 +120,7 @@ When you touch caching, building, or the schema:
 ## Submitting a PR
 
 1. For anything non-trivial, open (or link) an issue describing the change first.
-2. Branch, make the change, run `npm test` — all green on Node 18+.
+2. Branch, make the change, run `npm test` — all green on Node 20+.
 3. Tests are dependency-free black-box drivers over throwaway git repos (see
    `test/helpers.mjs`). New behavior needs a test in that style.
 4. Keep the diff minimal and the output byte-identical for existing commands —

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -437,8 +437,12 @@ post-distribution demand asks for Python (Batch 2's seam makes it a 1–2 week a
   4× with divergent failure behavior — unify once modularized. *(low)*
 - [ ] Duplicated recursive dir walk between `sourceFingerprint()` and `makeProject()`
   (`agentmap.mjs:431`) — extract one `walkSources()`. *(low)*
-- [ ] Node 18 is past EOL (Apr 2025) but in `engines` + CI matrix — decide support
-  policy. No `dependabot.yml`/renovate; `ts-morph` exact-pinned with no update path.
+- [x] Node 18 is past EOL (Apr 2025) but in `engines` + CI matrix — decide support
+  policy. Resolved: `engines` is `>=20` and the matrix is `[20, 22, 24]`. The floor
+  is set by the dependency tree, not by EOL dates — `brace-expansion` (via ts-morph
+  → @ts-morph/common → minimatch) declares `20 || >=22`, so `>=18` was a claim the
+  tree contradicted. `dependabot.yml` now covers npm + Actions, with `ts-morph` on
+  the weekly update path.
 - [ ] Community health files: no `.github/ISSUE_TEMPLATE`, PR template,
   `CODE_OF_CONDUCT.md`, `FUNDING.yml`. CI Actions pinned by mutable tags (`@v5`),
   not SHA — a hardening gap the SECURITY.md advertises.

--- a/hooks/INSTALL.md
+++ b/hooks/INSTALL.md
@@ -19,7 +19,7 @@ itself (`ts-morph`), used when the map (re)builds.
 
 ## 0. Prerequisites
 
-- **Node 18+** on PATH.
+- **Node 20+** on PATH.
 - **agentmap installed.** Either:
   - install it: `npm i -D @raymondchins/agentmap` (then `npx @raymondchins/agentmap` works), or
   - install it globally: `npm i -g @raymondchins/agentmap` (then `agentmap` works).

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "agentmap": "agentmap.mjs"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/@ts-morph/common": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "eval": "node eval/eval.mjs"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "dependencies": {
     "ts-morph": "28.0.0"

--- a/test/vue-sfc/fixtures.mjs
+++ b/test/vue-sfc/fixtures.mjs
@@ -13,8 +13,8 @@
 
 // Static ESM import of the shared harness. Must NOT be a sync `require()` of
 // helpers.mjs — `require()` of an ES module is only supported on Node 22.12+,
-// so the old createRequire() form threw ERR_REQUIRE_ESM on the Node 18 CI leg
-// (engines still declares node >=18). A static import works on every version.
+// so the old createRequire() form threw ERR_REQUIRE_ESM on the lowest CI leg
+// (engines declares node >=20). A static import works on every version.
 import { run } from "../helpers.mjs";
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What & why

Closes the `ROADMAP.md` housekeeping item *"Node 18 is past EOL (Apr 2025) but in `engines` + CI matrix — decide support policy."*

**`engines` was factually wrong.** `brace-expansion` — reached via `ts-morph → @ts-morph/common → minimatch`, and bumped to 5.0.8 in #39 for GHSA-mh99-v99m-4gvg — declares `"20 || >=22"`. It's the tightest constraint in the tree; every other installed package still allows 18:

```
balanced-match    18 || 20 || >=22
brace-expansion   20 || >=22     <-- the floor
minimatch         18 || 20 || >=22
```

So `>=18` became a claim the installed tree contradicted the moment that security fix landed. npm only *warns* on a transitive `engines` mismatch — which is why the Node 18 CI leg stayed green — but **pnpm, and anyone with `engine-strict=true`, got a hard install failure**.

**Why `>=20` and not `>=22`.** The floor is set by the dependency tree, not by EOL dates. `>=22` is also defensible on EOL grounds (Node 20 went EOL Apr 2026), but it breaks Node 20 users for no correctness reason — the tree runs fine there. agentmap's own code uses nothing above Node 18; this change is purely about the manifest telling the truth. If you'd rather take the EOL-hygiene line, `>=22` is a one-line follow-up.

**Matrix → `[20, 22, 24]`**: new floor, current LTS, forward coverage — same three-leg cost as `[18, 20, 22]`.

Docs updated in lockstep: `CONTRIBUTING.md` (×2), `hooks/INSTALL.md`, PR template, issue template, and a stale parenthetical in `test/vue-sfc/fixtures.mjs`. `ROADMAP.md` item marked resolved.

**Version deliberately left at 0.15.1**, entry filed under `CHANGELOG [Unreleased]` per the Keep a Changelog convention — cutting the release is your call, not this PR's.

## Checklist

- [x] `node --test test/` passes locally (Node 20+). — 356/356 on Node 22, the only runtime available locally; the **20 and 24 legs are verified by this PR's CI**.
- [x] No new runtime dependency (ts-morph stays the only one).
- [x] Still a single published artifact (`agentmap.mjs`, `#!/usr/bin/env node` shebang intact).
- [x] Freshness invariant intact — no cache/freshness logic touched.
- [x] If `map.json` shape changed: `SCHEMA_VERSION` bumped. — n/a, no schema change.
- [x] Output of shipped commands is byte-identical — no CLI output affected; `npm pack` unchanged at 21 files / 99.1 kB.
- [x] Docs / CHANGELOG updated if user-facing. — yes, all five doc sites + CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QToCLNU4rAYgf79Y7HTfUo)_