### PR TITLE
fix(callers): dotted JSX tags, anonymous-callback callers, `new Foo()`, and a precomputed call-edge cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,41 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Fixed
+- **`<Foo.Bar />` was never a call site — the whole branch was dead code since 0.17.0.**
+  `invocationOf()` reached for the tag holder with
+  `id.getParentIfKind(SyntaxKind.JsxMemberExpression)`, but **TypeScript has no
+  `JsxMemberExpression` SyntaxKind** — that is a Babel/ESTree node type, so the
+  lookup read `undefined` off the enum, `getParentIfKind(undefined)` never matched,
+  and `tagHolder` fell back to the bare identifier. `getTagNameNode()` returns the
+  member expression, so the identity check failed and every dotted tag was dropped.
+  TypeScript models a dotted JSX tag name as a plain `PropertyAccessExpression`,
+  which the function already computes one line earlier as `pa`. Now `tagHolder =
+  pa ?? id`. `import * as UI from "./widget"` + `<UI.Widget />` is found;
+  `--callers` on a namespace-imported component went 10 → 11 sites on the JSX
+  fixture, with no change to any other pattern.
+
+  Still not resolved (a ts-morph limitation, not this bug): aliasing a component
+  through an object literal — `const UI = { Widget }` then `<UI.Widget />`.
+  `findReferences` returns only the import and the shorthand property for that
+  file, never the render site.
+
+- **Call sites inside anonymous callbacks reported `<module>` instead of the
+  component that owns them.** The enclosing-scope lookup stopped at the *first*
+  function ancestor. For `{items.map(x => <Row key={x.id} />)}` that ancestor is the
+  anonymous `.map()` arrow, which has no name and is not the initializer of a
+  variable declaration — so the caller degraded to `<module>` even though a named
+  component plainly encloses it. Same for IIFEs and `startTransition(async () => …)`.
+  Measured on two real React repos: **11 of 43** JSX call sites in one, **6 of 95**
+  across another, all in this one shape; the non-JSX control had zero.
+
+  `enclosing()` now walks *outward* through anonymous ancestors until a named owner
+  appears (variable-declared arrow/function expression, object-literal property,
+  named function expression, function/method/class declaration), and is hoisted so
+  the single-hop `--callers` path shares it with the transitive `--depth > 1` path
+  instead of keeping a weaker copy. `<module>` now means genuinely top-level rather
+  than "wrapped in a callback". Across 65 call sites in two repos: **0 remaining
+  `<module>`**, recall unchanged.
+
 - **A file that failed to parse vanished from the map, and the map said nothing.**
   Per-file parse errors are caught so one bad file cannot abort the build — correct,
   and unchanged. But the file never reached `files[path]`, so `map.json` reported a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- **`new Foo()` was not a call site.** `invocationOf()` matched only
+  `CallExpression`, never `NewExpression`, so a class reachable ONLY via `new`
+  reported **zero callers** — silently, exit 1, indistinguishable from genuinely
+  unused. Two lines, but the blast radius was the whole class of
+  instantiated-not-invoked symbols, and it hit the transitive `--depth >= 2` path
+  too since that shares the predicate. Found by diffing the live walk against the
+  new call-edge sweep, which had swept `NewExpression` all along.
+
+- **A symbol exported under a different name than its declaration was invisible to
+  the cached path.** `export { impl as Widget }` binds the export to `Widget` while
+  the node stays named `impl`; the sidecar keyed edges on the declaration's own
+  name, but queries resolve by the EXPORTED name, so `--callers Widget` returned 0
+  from cache and 1 live. Edges now carry every name the defining file exports a
+  declaration as, read from the same `getExportedDeclarations()` the query resolves
+  through.
+
+- **A reassigned local alias fabricated a call.** For `const wrapped = helper;
+  wrapped()`, go-to-definition walks through the trivial reassignment and returns
+  BOTH the local binding and `helper`. The sweep emitted an edge for each, crediting
+  `helper` with a call site that never names it — the live reference walk reports
+  none. Resolution now stops at a local value binding when one is among the targets.
+
+### Known
+- A barrel that BOTH `export * from "./a"` and locally redefines the same name is
+  the one shape where the cached and live paths still disagree — and the cache is
+  the correct one. ES semantics say the local binding shadows the star-export, so
+  `a.ts`'s copy is unreachable; the sweep agrees (0 callers) while
+  `findReferencesAsNodes()` over-reports through the star chain (1). Left as-is
+  rather than teaching the cache to reproduce a wrong answer.
+
 ### Added
 - **`--build-edges`: a precomputed call-edge index, so `--callers` stops paying the
   type-checker on every query.** `--callers` was ~1500ms and the reason was not the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,21 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   rather than teaching the cache to reproduce a wrong answer.
 
 ### Added
+- **`--calls` and `--callers --depth N` now read the same cache `--callers` does.**
+  The sidecar always stored both ends of every edge, so the outgoing direction is
+  the same table filtered by an edge's TAIL instead of its head, and the
+  transitive walk is a BFS rejoining tail to head. Both were still paying the full
+  live type-checker walk. **~800-1500ms -> 84ms.**
+
+  Reaching byte-identity took three details worth recording, each found by diffing
+  the two paths rather than assuming: outgoing rows tie-break by callee NAME (not
+  line — the line there is a declaration, which carries no ordering meaning);
+  `via` is user-visible provenance spelled `file:caller:DECLARATION-line`, so edges
+  had to start carrying the caller's own declaration line; and self-recursion is
+  not an outgoing edge. Edge rows also gained the callee's declaration line and
+  kind. Format bumped 2 -> 4, so any sidecar predating these fields is rejected
+  rather than half-read into rows with undefined columns.
+
 - **`--routes` / `--route <url|file>`: a Next.js App Router route table whose URLs
   are real.** The bar is a URL you can paste into a browser, and that is exactly
   where a convention-only extractor goes wrong: a `(group)` folder organises the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,29 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   rather than teaching the cache to reproduce a wrong answer.
 
 ### Added
+- **`--routes` / `--route <url|file>`: a Next.js App Router route table whose URLs
+  are real.** The bar is a URL you can paste into a browser, and that is exactly
+  where a convention-only extractor goes wrong: a `(group)` folder organises the
+  tree and contributes NOTHING to the URL, but it DOES contribute a layout.
+  Measured against a 394-file App Router repo, a competing tool emitted 35 routes
+  of a true 64, and 31 of those 35 carried the route group in the URL
+  (`/(app)/brands/:id` — a path that 404s), leaving 4 usable. It indexed none of
+  the 13 API routes and none of the 16 `export { default } from` shim routes.
+
+  `--routes` gets all 64: groups stripped, `[id]` -> `:id`, `[...rest]` -> `*rest`,
+  `[[...rest]]` -> `*rest?`, `@slot` contributing no segment, the root page as `/`
+  rather than `/page.tsx`, HTTP methods per API route, and shim routes resolved to
+  their target. `--route` answers both directions — a concrete URL
+  (`/brands/123`, matched through dynamic segments) or a file path — and reports
+  the layout chain and RSC boundary.
+
+  A layout chain is reported for pages ONLY: `route.ts` returns a Response and
+  never renders, so claiming layouts wrap it would be a confident falsehood.
+
+  Computed on demand from the map's own file list — no new persisted state, no
+  staleness class, ~80ms on 400 files. Repos without `app/`/`src/app/` say so and
+  exit 1 rather than inventing an empty table.
+
 - **`--build-edges`: a precomputed call-edge index, so `--callers` stops paying the
   type-checker on every query.** `--callers` was ~1500ms and the reason was not the
   reference search — profiling put ~750-860ms, about half the total, in the FIRST

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,17 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   declaration as, read from the same `getExportedDeclarations()` the query resolves
   through.
 
+- **A corrupt call-edge cache degraded quietly.** A missing or stale sidecar is
+  routine and stays silent, but an unreadable or malformed one still answered
+  correctly from the live walk 20x slower with nothing on stderr to explain why.
+  Now one stderr line naming the file and the rebuild command; still never fatal.
+
+- **An upgrade could serve edge rows written by older logic.** The sidecar key
+  folded in `SCHEMA_VERSION`, which versions `map.json` — not the edge rows — so
+  changing what a row contains did not invalidate it. Since a missing edge is
+  indistinguishable from "no caller", that lands as a confident wrong answer with
+  no symptom. `EDGES_FORMAT` is now part of the key and bumps independently.
+
 - **A reassigned local alias fabricated a call.** For `const wrapped = helper;
   wrapped()`, go-to-definition walks through the trivial reassignment and returns
   BOTH the local binding and `helper`. The sweep emitted an edge for each, crediting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+- **`--build-edges`: a precomputed call-edge index, so `--callers` stops paying the
+  type-checker on every query.** `--callers` was ~1500ms and the reason was not the
+  reference search — profiling put ~750-860ms, about half the total, in the FIRST
+  touch of the type-checker (`getExportedDeclarations()` forcing a full-program
+  bind), a cost that is nearly fixed: a 2-reference symbol pays the same as a
+  119-reference one, and scoping the ts-morph Project to a file's known dependents
+  (251 files -> 50) cut it only ~24%, because the bulk is binding `lib.d.ts` and
+  `@types`, not your code.
+
+  So the checker work moves off the query path entirely. `--build-edges` sweeps
+  every file once, resolves each call/JSX site through the same go-to-definition
+  primitive the live walk uses, and writes `.claude/agentmap/calledges.json`.
+  `--callers` then answers from that file: **1514ms -> 77ms** on a 252-file repo,
+  verified byte-identical to the live walk across 12 symbols there (including `cn`
+  at 119 call sites, and both definitions of an ambiguous `ToggleSwitch`).
+
+  It is a cache, never a second source of truth. The sidecar is keyed to the exact
+  map it was derived from — HEAD, dirty fingerprint, schema — so an edit invalidates
+  it and the query silently falls back to the live walk. Corrupt file, missing file,
+  `--depth >= 2` (which needs findReferences-able nodes a JSON row cannot carry),
+  and `--calls` (different output shape) all fall back the same way. There is no
+  configuration in which a stale sidecar is served.
+
+  Building it costs ~4x a map rebuild (~9s on 252 files) and that is irreducible:
+  the per-site `getDefinitionNodes()` call is 89-94% of it, and a prefilter that
+  skips candidates absent from a file's declared/imported names drops 35-44% of real
+  edges, because React code overwhelmingly calls names bound at nested scope
+  (destructured hook state, nested helpers). A correct prefilter only recovers
+  ~25-35% of the cost. So the step is explicit, never implicit: the post-commit hook
+  runs it detached, lock-guarded and timeout-capped, where nothing waits on it.
+  `AGENTMAP_HOOK_EDGES=0` skips it. `--relates`/`--find`/`--hubs`/`--map` never read
+  or write it and are unchanged.
+
 ### Fixed
 - **`<Foo.Bar />` was never a call site — the whole branch was dead code since 0.17.0.**
   `invocationOf()` reached for the tag holder with

--- a/agentmap.mjs
+++ b/agentmap.mjs
@@ -42,6 +42,12 @@ const FACTS = ".claude/agentmap/facts.json"; // raw per-file facts snapshot for 
 // is never an error: --callers silently falls back to the live ts-morph walk it
 // has always used, so this is a pure speedup with no new failure mode.
 const EDGES = ".claude/agentmap/calledges.json";
+// Version of the EDGE ROW FORMAT, independent of SCHEMA_VERSION (which versions
+// map.json). Bump on any change to what a row means or contains — otherwise an
+// upgrade silently serves a sidecar written by older logic, and since a missing
+// edge just looks like "no caller", the failure is a confident wrong answer with
+// no symptom. Bumped to 2 when rows gained export-alias names.
+const EDGES_FORMAT = 2;
 // Bumped 2 → 3: Vue SFC support. `.vue` files now appear in the map and the
 // source-discovery / freshness checks treat them as first-class source files.
 // Bumped 3 → 4: per-file `locals` (non-exported top-level declarations) now
@@ -3550,6 +3556,7 @@ const enclosingName = (id, SyntaxKind) => enclosingOwner(id, SyntaxKind).name;
 function edgeKey(data) {
   return [
     SCHEMA_VERSION,
+    `e${EDGES_FORMAT}`,
     data.generatedSha || "",
     data.dirtyFingerprint || "",
     data.fingerprint || "",

--- a/agentmap.mjs
+++ b/agentmap.mjs
@@ -47,7 +47,7 @@ const EDGES = ".claude/agentmap/calledges.json";
 // upgrade silently serves a sidecar written by older logic, and since a missing
 // edge just looks like "no caller", the failure is a confident wrong answer with
 // no symptom. Bumped to 2 when rows gained export-alias names.
-const EDGES_FORMAT = 2;
+const EDGES_FORMAT = 4;
 // Bumped 2 → 3: Vue SFC support. `.vue` files now appear in the map and the
 // source-discovery / freshness checks treat them as first-class source files.
 // Bumped 3 → 4: per-file `locals` (non-exported top-level declarations) now
@@ -3826,14 +3826,24 @@ function buildCallEdges() {
       });
       const resolved = rebind ? [rebind] : targets;
       const callerLine = idNode.getStartLineNumber();
-      const callerName = enclosingName(idNode, SyntaxKind);
+      // Keep the owner NODE too, not just its name: the transitive walk's `via`
+      // key is `file:caller:declLine`, and declLine is the enclosing symbol's own
+      // declaration line — not the call-site line.
+      const owner = enclosingOwner(idNode, SyntaxKind);
+      const callerName = owner.name;
+      const callerDeclLine = owner.node?.getStartLineNumber?.() ?? callerLine;
       for (const d of resolved) {
         const tsf = d.getSourceFile();
         if (tsf.isInNodeModules() || tsf.isDeclarationFile()) continue;
         const calleeFile = rel(tsf.getFilePath().replace(/\\/g, "/"));
         if (!inProject(calleeFile)) continue;
+        // The callee's OWN declaration line/kind — what --calls prints for each
+        // outgoing row, and what lets the transitive walk rejoin an edge's head
+        // to the next hop's tail.
+        const calleeLine = d.getStartLineNumber?.() ?? 0;
+        const calleeKind = d.getKindName?.() ?? "";
         for (const calleeName of exportedNamesOf(d, tsf)) {
-          edges.push({ callerFile, callerLine, callerName, calleeFile, calleeName, kind: isJsx ? "jsx" : "call" });
+          edges.push({ callerFile, callerLine, callerName, callerDeclLine, calleeFile, calleeName, calleeLine, calleeKind, kind: isJsx ? "jsx" : "call" });
         }
       }
     }
@@ -3892,9 +3902,9 @@ function callGraph(symbolName, { inFilter = "", direction = "callers", depth = 1
   // shape and --depth >= 2 needs findReferences-able NODES to recurse on, which a
   // JSON row cannot carry; both keep the live walk. A missing/stale sidecar just
   // falls through, so this can only ever be faster, never wrong.
-  if (direction === "callers" && maxDepth === 1) {
+  {
     const cached = readCallEdges(data);
-    if (cached) {
+    if (cached && direction === "callers" && maxDepth === 1) {
       const seen = new Set();
       const sites = [];
       for (const e of cached) {
@@ -3912,6 +3922,89 @@ function callGraph(symbolName, { inFilter = "", direction = "callers", depth = 1
         command: "callers", query: symbolName, symbol: symbolName, file: fileKey,
         total: sites.length, shown: shown.length, truncated: sites.length > shown.length,
         callers: shown, _code: sites.length ? 0 : 1,
+      };
+    }
+    // OUTGOING from cache: the same table read from the other end. An edge's tail
+    // is (callerFile, callerName) — the enclosing named owner of the call site —
+    // so "what does X call" is just the rows whose tail is X.
+    if (cached && direction === "calls" && maxDepth === 1) {
+      const seen = new Set();
+      const targets = [];
+      for (const e of cached) {
+        if (e.callerFile !== fileKey || e.callerName !== symbolName) continue;
+        if (e.calleeFile === fileKey && e.calleeName === symbolName) continue; // self-recursion isn't an outgoing edge
+        const dedupe = `${e.calleeFile}:${e.calleeLine}:${e.calleeName}`;
+        if (seen.has(dedupe)) continue;
+        seen.add(dedupe);
+        targets.push({ file: e.calleeFile, line: e.calleeLine, name: e.calleeName, kind: e.calleeKind });
+      }
+      // Outgoing rows tie-break by callee NAME, not line — matching the live walk.
+      // (Incoming rows tie-break by line, because there the line IS the call site;
+      // here it is the callee's declaration line, which carries no ordering
+      // meaning to a reader scanning "what does this call".)
+      targets.sort((x, y) =>
+        ((data.files[y.file]?.pagerank ?? 0) - (data.files[x.file]?.pagerank ?? 0))
+        || (x.file < y.file ? -1 : x.file > y.file ? 1 : (x.name < y.name ? -1 : x.name > y.name ? 1 : 0)));
+      const shown = targets.slice(0, SYMBOL_MATCH_LIMIT);
+      return {
+        command: "calls", query: symbolName, symbol: symbolName, file: fileKey,
+        total: targets.length, shown: shown.length, truncated: targets.length > shown.length,
+        calls: shown, _code: targets.length ? 0 : 1,
+      };
+    }
+    // TRANSITIVE from cache. The live walk recurses on findReferences-able NODES;
+    // here the equivalent is rejoining an edge's tail (callerFile, callerName) to
+    // the next hop's head (calleeFile, calleeName). Rows dedup by call SITE,
+    // expansion dedups by enclosing SYMBOL — the same two-concern split, and the
+    // same frontier/total caps, so a hub cannot blow the result open.
+    if (cached && direction === "callers" && maxDepth > 1) {
+      const byCallee = new Map();
+      for (const e of cached) {
+        const k = `${e.calleeFile}\x00${e.calleeName}`;
+        (byCallee.get(k) ?? byCallee.set(k, []).get(k)).push(e);
+      }
+      const seenSite = new Set();
+      const visitedSym = new Set([`${fileKey}\x00${symbolName}`]);
+      const out = [];
+      let frontier = [{ file: fileKey, name: symbolName, key: null }];
+      let hop = 0, capped = false;
+      while (frontier.length && hop < maxDepth && !capped) {
+        hop++;
+        const next = [];
+        for (const fr of frontier) {
+          for (const e of byCallee.get(`${fr.file}\x00${fr.name}`) ?? []) {
+            const siteKey = `${e.callerFile}:${e.callerLine}`;
+            if (seenSite.has(siteKey)) continue;
+            seenSite.add(siteKey);
+            out.push({ file: e.callerFile, line: e.callerLine, caller: e.callerName, depth: hop, via: fr.key });
+            if (out.length >= CLOSURE_TOTAL_CAP) { capped = true; break; }
+            if (e.callerName === "<module>") continue;   // module scope has no symbol to recurse on
+            // TWO different keys, deliberately. The dedup key is internal cycle-
+            // guard identity — (file, name), NUL-separated so a path can never
+            // forge a collision. `via` is user-visible and must reproduce the live
+            // walk byte-for-byte, which spells it file:caller:DECLARATION-line —
+            // the enclosing symbol's own line, not the call-site line.
+            const dedupK = `${e.callerFile}\x00${e.callerName}`;
+            if (!visitedSym.has(dedupK)) {
+              visitedSym.add(dedupK);
+              next.push({
+                file: e.callerFile, name: e.callerName,
+                key: `${e.callerFile}:${e.callerName}:${e.callerDeclLine ?? e.callerLine}`,
+                pr: data.files[e.callerFile]?.pagerank ?? 0,
+              });
+            }
+          }
+          if (capped) break;
+        }
+        next.sort((a, b) => b.pr - a.pr);
+        frontier = next.slice(0, CLOSURE_FRONTIER_CAP);
+      }
+      out.sort((x, y) => (x.depth - y.depth)
+        || ((data.files[y.file]?.pagerank ?? 0) - (data.files[x.file]?.pagerank ?? 0))
+        || (x.file < y.file ? -1 : x.file > y.file ? 1 : x.line - y.line));
+      return {
+        command: "callers", query: symbolName, symbol: symbolName, file: fileKey, depth: maxDepth,
+        total: out.length, shown: out.length, truncated: capped, callers: out, _code: out.length ? 0 : 1,
       };
     }
   }

--- a/agentmap.mjs
+++ b/agentmap.mjs
@@ -3560,12 +3560,23 @@ function edgeKey(data) {
 // Read the sidecar, or null when it is absent / unreadable / keyed to a different
 // map. Never throws: every failure means "fall back to the live walk".
 function readCallEdges(data) {
-  if (!existsSync(EDGES)) return null;
-  try {
-    const c = JSON.parse(readFileSync(EDGES, "utf8"));
-    if (c.schema !== SCHEMA_VERSION || c.key !== edgeKey(data)) return null;
-    return Array.isArray(c.edges) ? c.edges : null;
-  } catch { return null; }
+  if (!existsSync(EDGES)) return null;          // never built — the normal state
+  let c;
+  try { c = JSON.parse(readFileSync(EDGES, "utf8")); }
+  catch {
+    // Present but unreadable. Staleness is routine and stays quiet; a CORRUPT
+    // cache is not, and answering correctly-but-20x-slower with no explanation is
+    // the kind of silent degradation that never gets diagnosed. One line, stderr,
+    // never fatal — the answer below is still the authoritative live walk.
+    console.error(`# agentmap: ${EDGES} unreadable — using the live walk (rebuild with \`agentmap --build-edges\`)`);
+    return null;
+  }
+  if (c.schema !== SCHEMA_VERSION || c.key !== edgeKey(data)) return null; // stale: expected, silent
+  if (!Array.isArray(c.edges)) {
+    console.error(`# agentmap: ${EDGES} malformed — using the live walk (rebuild with \`agentmap --build-edges\`)`);
+    return null;
+  }
+  return c.edges;
 }
 
 // Sweep every in-project file once and record every resolvable call/JSX site.

--- a/agentmap.mjs
+++ b/agentmap.mjs
@@ -3480,9 +3480,13 @@ function mcpResetCache() { _mcpMapCache = null; }
 // module-scope helper against the lazily-loaded ts-morph (same shape as
 // rscBoundary at :450).
 function invocationOf(id, SyntaxKind) {
-  let call = id.getParentIfKind(SyntaxKind.CallExpression);
+  // `new Foo()` is an invocation exactly as much as `foo()` is. Only CallExpression
+  // was matched here, so a class reachable ONLY via `new` reported ZERO callers —
+  // silently, with exit 1, indistinguishable from genuinely-unused. It bit the
+  // transitive --depth path too, since that shares this predicate.
+  let call = id.getParentIfKind(SyntaxKind.CallExpression) ?? id.getParentIfKind(SyntaxKind.NewExpression);
   const pa = id.getParentIfKind(SyntaxKind.PropertyAccessExpression);
-  if (!call && pa) call = pa.getParentIfKind(SyntaxKind.CallExpression);
+  if (!call && pa) call = pa.getParentIfKind(SyntaxKind.CallExpression) ?? pa.getParentIfKind(SyntaxKind.NewExpression);
   if (call && call.getExpression() === (pa ?? id)) return call;
 
   // `<Foo.Bar />` puts the identifier under a member expression; the element's
@@ -3579,6 +3583,37 @@ function buildCallEdges() {
   const cwd = process.cwd().replace(/\\/g, "/");
   const rel = (p) => { const abs = p.replace(/\\/g, "/"); return (vueMap[abs] || abs).replace(cwd + "/", ""); };
   const inProject = (k) => Object.prototype.hasOwnProperty.call(data.files, k);
+  // A declaration's own name is NOT always the name callers query by:
+  // `export { impl as Widget }` binds the export to `Widget` while the node is
+  // still named `impl`, and Phase A resolves the query through
+  // getExportedDeclarations() — i.e. by the EXPORTED name. Keying edges on
+  // d.getName() alone therefore made such a symbol look uncalled. Build the
+  // inverse (declaration -> every name its own file exports it as) from the same
+  // API Phase A trusts, memoised per file since the sweep revisits callee files
+  // constantly.
+  const aliasCache = new Map();
+  const exportedNamesOf = (d, tsf) => {
+    const key = tsf.getFilePath();
+    let byNode = aliasCache.get(key);
+    if (!byNode) {
+      byNode = new Map();
+      try {
+        for (const [name, decls] of tsf.getExportedDeclarations()) {
+          for (const dd of decls) {
+            const at = `${dd.getStartLineNumber?.() ?? 0}:${dd.getKindName?.() ?? ""}`;
+            if (!byNode.has(at)) byNode.set(at, new Set());
+            byNode.get(at).add(name);
+          }
+        }
+      } catch { /* unreadable exports — fall back to the declaration's own name */ }
+      aliasCache.set(key, byNode);
+    }
+    const names = new Set();
+    const own = d.getName?.();
+    if (own) names.add(own);
+    for (const n of byNode.get(`${d.getStartLineNumber?.() ?? 0}:${d.getKindName?.() ?? ""}`) ?? []) names.add(n);
+    return names;
+  };
   const edges = [];
   let sites = 0;
   for (const sf of project.getSourceFiles()) {
@@ -3605,15 +3640,28 @@ function buildCallEdges() {
       if (!idNode) continue; // computed / parenthesized / dynamic — the same honest limit --calls has
       let targets;
       try { targets = idNode.getDefinitionNodes?.() || []; } catch { continue; }
+      // `const wrapped = helper; wrapped()` — go-to-definition helpfully walks
+      // THROUGH the trivial reassignment and returns BOTH the local `wrapped`
+      // binding and `helper` itself. Emitting every target made `helper` look
+      // called from a site that never names it, which the live reference walk
+      // rightly does not report (the reference there is `wrapped`, not `helper`).
+      // A local value binding is where resolution stops: keep only it.
+      const rebind = targets.find((d) => {
+        const k = d.getKindName?.();
+        return (k === "VariableDeclaration" || k === "BindingElement" || k === "Parameter")
+          && d.getSourceFile().getFilePath() === sf.getFilePath();
+      });
+      const resolved = rebind ? [rebind] : targets;
       const callerLine = idNode.getStartLineNumber();
       const callerName = enclosingName(idNode, SyntaxKind);
-      for (const d of targets) {
+      for (const d of resolved) {
         const tsf = d.getSourceFile();
         if (tsf.isInNodeModules() || tsf.isDeclarationFile()) continue;
         const calleeFile = rel(tsf.getFilePath().replace(/\\/g, "/"));
         if (!inProject(calleeFile)) continue;
-        const calleeName = d.getName?.() ?? idNode.getText();
-        edges.push({ callerFile, callerLine, callerName, calleeFile, calleeName, kind: isJsx ? "jsx" : "call" });
+        for (const calleeName of exportedNamesOf(d, tsf)) {
+          edges.push({ callerFile, callerLine, callerName, calleeFile, calleeName, kind: isJsx ? "jsx" : "call" });
+        }
       }
     }
   }

--- a/agentmap.mjs
+++ b/agentmap.mjs
@@ -3457,9 +3457,14 @@ function invocationOf(id, SyntaxKind) {
   if (!call && pa) call = pa.getParentIfKind(SyntaxKind.CallExpression);
   if (call && call.getExpression() === (pa ?? id)) return call;
 
-  // `<Foo.Bar />` puts the identifier under a JsxMemberExpression; the element's
-  // tag-name node is that member expression, not the bare identifier.
-  const tagHolder = id.getParentIfKind(SyntaxKind.JsxMemberExpression) ?? id;
+  // `<Foo.Bar />` puts the identifier under a member expression; the element's
+  // tag-name node is that member expression, not the bare identifier. TypeScript
+  // models a dotted JSX tag as a plain PropertyAccessExpression — there is NO
+  // `SyntaxKind.JsxMemberExpression` (that is a Babel/ESTree node type, and
+  // reading it off SyntaxKind yields `undefined`, so getParentIfKind never
+  // matched and this whole branch was dead from 0.17.0). `pa` above already
+  // holds that node.
+  const tagHolder = pa ?? id;
   for (const kind of [SyntaxKind.JsxSelfClosingElement, SyntaxKind.JsxOpeningElement]) {
     const el = tagHolder.getParentIfKind(kind);
     if (el && el.getTagNameNode() === tagHolder) return el;
@@ -3654,27 +3659,44 @@ function callGraph(symbolName, { inFilter = "", direction = "callers", depth = 1
   // is. This is the compiler-accuracy line — a type-position mention, a re-export, a
   // bare value reference, or a same-named local in another file binds to a DIFFERENT
   // symbol and never reaches here.
-  if (maxDepth > 1) {
-    // Transitive INCOMING BFS: to recurse UP one hop we need a findReferences-able
-    // node for the ENCLOSING symbol of each call site. `enclosing()` returns that
-    // node (a FunctionDeclaration/Method/Class directly; the VariableDeclaration
-    // name node for an arrow-const; null for a module-level or anonymous caller =
-    // a leaf). Rows dedup by call SITE; expansion dedups by enclosing SYMBOL (the
-    // cycle guard) — two separate concerns. Frontier + total caps bound hubs.
-    const enclosing = (id) => {
-      const enc = id.getFirstAncestor((an) => /Function|Method|Constructor|ClassDeclaration/.test(an.getKindName()));
+  // Resolve the named function/class that lexically encloses a call site. Shared by
+  // the single-hop and the transitive path. An anonymous callback (`.map(x => <Foo/>)`,
+  // an IIFE, `startTransition(async () => …)`) is NOT an answer — it has no name worth
+  // printing and no findReferences-able node to recurse on — so keep walking OUTWARD
+  // until a named owner appears rather than giving up at the first anonymous ancestor.
+  // `node` is the findReferences-able node for the BFS to recurse on (null when the
+  // owner cannot be recursed on); `name` is what gets printed. "<module>" now means
+  // genuinely top-level, not merely "wrapped in a callback".
+  const enclosing = (id) => {
+    let cur = id;
+    for (;;) {
+      const enc = cur.getFirstAncestor((an) => /Function|Method|Constructor|ClassDeclaration/.test(an.getKindName()));
       if (!enc) return { name: "<module>", node: null };
       const k = enc.getKindName();
-      let node = enc, name = enc.getName?.();
-      if (k === "Constructor") { const cls = enc.getFirstAncestorByKind(SyntaxKind.ClassDeclaration); node = cls ?? null; name = cls?.getName?.() ?? name; }
-      else if (/ArrowFunction|FunctionExpression/.test(k)) {
-        const vd = enc.getFirstAncestorByKind(SyntaxKind.VariableDeclaration);
-        if (vd && vd.getInitializer?.() === enc && vd.getNameNode?.().getKind?.() === SyntaxKind.Identifier) { node = vd.getNameNode(); name = vd.getName(); }
-        else node = null;
+      if (k === "Constructor") {
+        const cls = enc.getFirstAncestorByKind(SyntaxKind.ClassDeclaration);
+        if (cls?.getName?.()) return { name: cls.getName(), node: cls };
+      } else if (/ArrowFunction|FunctionExpression/.test(k)) {
+        const p = enc.getParent();
+        const pk = p?.getKind?.();
+        // `const Foo = () => …` / `const Foo = function () {…}`
+        if (pk === SyntaxKind.VariableDeclaration && p.getInitializer?.() === enc
+          && p.getNameNode?.().getKind?.() === SyntaxKind.Identifier) return { name: p.getName(), node: p.getNameNode() };
+        // `{ foo: () => … }`
+        if (pk === SyntaxKind.PropertyAssignment && p.getName?.()) return { name: p.getName(), node: null };
+        // named function expression: `foo(function bar() {…})`
+        if (enc.getName?.()) return { name: enc.getName(), node: null };
+      } else if (enc.getName?.()) {
+        return { name: enc.getName(), node: enc };
       }
-      if (!name) { name = "<module>"; node = null; }
-      return { name, node };
-    };
+      cur = enc; // anonymous / unnamed — keep walking outward
+    }
+  };
+  if (maxDepth > 1) {
+    // Transitive INCOMING BFS: to recurse UP one hop we need a findReferences-able
+    // node for the ENCLOSING symbol of each call site — that is `enclosing().node`
+    // above. Rows dedup by call SITE; expansion dedups by enclosing SYMBOL (the
+    // cycle guard) — two separate concerns. Frontier + total caps bound hubs.
     const seedKey = (d) => `${rel(d.getSourceFile().getFilePath().replace(/\\/g, "/"))}:${d.getName?.() ?? symbolName}:${d.getStartLineNumber?.() ?? 0}`;
     const visitedSym = new Set(decls.map(seedKey)); // enclosing-symbol expansion dedup (cycle guard)
     const seenSite = new Set();                     // global row dedup by call site
@@ -3727,9 +3749,7 @@ function callGraph(symbolName, { inFilter = "", direction = "callers", depth = 1
       const dedupe = `${file}:${line}`;
       if (seen.has(dedupe)) continue;
       seen.add(dedupe);
-      const enc = id.getFirstAncestor((an) => /Function|Method|Constructor|ClassDeclaration/.test(an.getKindName()));
-      const caller = enc?.getName?.() || enc?.getParentIfKind?.(SyntaxKind.VariableDeclaration)?.getName?.() || "<module>";
-      sites.push({ file, line, caller });
+      sites.push({ file, line, caller: enclosing(id).name });
     }
   }
   // Rank by the CALLING file's PageRank so important callers survive the cap (same

--- a/agentmap.mjs
+++ b/agentmap.mjs
@@ -2850,6 +2850,11 @@ Query commands:
   --symbols [n]        top-n Aider-style ranked symbols (default 30)
   --feature <name>     files composing a feature + external dependents
   --features           list all features (route segments) by size
+  --routes             Next.js App Router route table: real URLs (route groups
+                       stripped, [id] -> :id), HTTP methods per API route, the
+                       layout chain, and re-export shim aliases
+  --route <url|file>   what serves this URL (or which URL a file serves):
+                       matched file, methods, layout chain, RSC boundary
   --hubs               top files by PageRank importance
   --print              dump the full cached map as JSON
   --export <mermaid|dot> [--focus <p>]
@@ -2921,14 +2926,14 @@ async function main() {
     "--help", "-h", "--version", "-v", "--install-hooks", "--hook-status", "--doctor", "--install-skill", "--platform", "--project", "--global",
     "--dry-run", "--setup-mcp", "--mcp", "--build-edges",
     "--any", "--find", "--search", "--relates", "--callers", "--calls", "--in", "--depth", "--map", "--export", "--focus", "--tokens",
-    "--symbols", "--feature", "--features", "--hubs",
+    "--symbols", "--feature", "--features", "--hubs", "--routes", "--route",
   ]);
 
   // A token consumed as the VALUE of a value-taking flag is never itself a flag —
   // so a dash-leading query like `--any "-O/bin/sh"` is bound as the query, not
   // mistaken for an unknown flag. (arg() already rejects a "--"-leading value, so
   // `--any --foo` still falls through to the missing-arg guard instead.)
-  const VALUE_FLAGS = new Set(["--any", "--find", "--search", "--relates", "--callers", "--calls", "--in", "--depth", "--export", "--feature", "--focus", "--tokens", "--symbols", "--platform"]);
+  const VALUE_FLAGS = new Set(["--any", "--find", "--search", "--relates", "--callers", "--calls", "--in", "--depth", "--export", "--feature", "--focus", "--tokens", "--symbols", "--platform", "--route"]);
   const valueIdx = new Set();
   for (let i = 0; i < args.length - 1; i++) if (VALUE_FLAGS.has(args[i])) valueIdx.add(i + 1);
 
@@ -2965,6 +2970,7 @@ async function main() {
     "--hook-status": [], "--doctor": [], "--setup-mcp": ["--dry-run"], "--build-edges": [],
     "--any": [], "--find": [], "--search": [], "--relates": [], "--callers": ["--in", "--depth"], "--calls": ["--in", "--depth"], "--map": ["--focus", "--tokens"], "--export": ["--focus"],
     "--symbols": [], "--feature": [], "--features": [], "--hubs": [], "--print": [],
+    "--routes": [], "--route": [],
   };
   const presentCommands = Object.keys(COMMANDS).filter(has);
   if (presentCommands.length > 1) {
@@ -3399,6 +3405,56 @@ async function main() {
       console.log(`features (${list.length}):`);
       for (const [k, n] of list) console.log(`  ${k} (${n} files)`);
     });
+  } else if (has("--routes")) {
+    const data = ensureFresh();
+    const routes = buildRouteTable(data);
+    if (!routes) {
+      out({ command: "routes", routes: [], reason: "no Next.js App Router directory (app/ or src/app/)", _code: 1 },
+        () => console.log("routes: no app/ or src/app/ directory — not a Next.js App Router project"));
+      process.exitCode = 1;
+    } else {
+      out({ command: "routes", total: routes.length, routes }, () => {
+        const pages = routes.filter((r) => r.kind === "page").length;
+        console.log(`routes (${routes.length}): ${pages} pages, ${routes.length - pages} api`);
+        for (const r of routes) {
+          const m = r.methods?.length ? ` [${r.methods.join(",")}]` : "";
+          const a = r.alias ? `  -> ${r.alias}` : "";
+          const b = r.boundary ? ` (${r.boundary})` : "";
+          console.log(`  ${r.url}${m}${b}  ${r.file}${a}`);
+        }
+      });
+    }
+  } else if (has("--route")) {
+    const raw = arg("--route");
+    if (!raw) { console.error("--route needs a URL or file, e.g. `--route /brands/123` (run --routes to list)"); process.exitCode = 2; }
+    else {
+      const data = ensureFresh();
+      const routes = buildRouteTable(data);
+      const hits = routes ? matchRoute(routes, raw) : [];
+      if (!hits.length) {
+        out({ command: "route", query: raw, matches: [], _code: 1 },
+          () => console.log(`route "${raw}": no match (run --routes to list)`));
+        process.exitCode = 1;
+      } else {
+        // Enrich each hit with what the map already knows: the modules the
+        // handler imports, flagged by RSC boundary — i.e. the server actions a
+        // page can actually reach.
+        const enriched = hits.map((r) => {
+          const f = data.files[r.file] || {};
+          const serverDeps = (f.imports || []).filter((i) => data.files[i]?.rsc === "server");
+          return { ...r, imports: f.imports || [], serverModules: serverDeps };
+        });
+        out({ command: "route", query: raw, total: enriched.length, matches: enriched }, () => {
+          for (const r of enriched) {
+            console.log(`${r.url}${r.methods?.length ? ` [${r.methods.join(",")}]` : ""}  (${r.kind})`);
+            console.log(`  serves: ${r.file}${r.boundary ? `  boundary: '${r.boundary}'` : ""}`);
+            if (r.alias) console.log(`  alias of: ${r.alias}`);
+            if (r.layoutChain.length) console.log(`  layouts (outer->inner): ${r.layoutChain.join(" -> ")}`);
+            if (r.serverModules.length) console.log(`  server modules: ${r.serverModules.join(", ")}`);
+          }
+        });
+      }
+    }
   } else if (has("--hubs")) {
     const data = ensureFresh();
     out({ command: "hubs", fileCount: data.fileCount, sha: data.generatedSha, hubs: data.hubs }, () => {
@@ -3508,6 +3564,105 @@ function invocationOf(id, SyntaxKind) {
     if (el && el.getTagNameNode() === tagHolder) return el;
   }
   return null;
+}
+
+// ---------------------------------------------------------------------------
+// Next.js App Router route table.
+//
+// Computed on demand from the filesystem rather than persisted: it is pure
+// readdir + string work (single-digit ms even on 400 files), so caching it would
+// buy nothing and add a staleness class. Nothing here touches map.json.
+//
+// The bar is a URL you can paste into a browser. That is precisely where a
+// convention-only extractor goes wrong: a `(group)` folder organises the tree
+// and contributes NOTHING to the URL, but it DOES contribute a layout. Emitting
+// `/(app)/brands/:id` — a path that 404s — is worse than emitting nothing,
+// because it looks authoritative.
+// ---------------------------------------------------------------------------
+const ROUTE_FILE_RE = /(^|\/)(page|route|layout)\.(t|j)sx?$/;
+const HTTP_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"];
+
+// One path segment -> its URL contribution, or null when it contributes none.
+function routeSegment(seg) {
+  if (/^\(.+\)$/.test(seg)) return null;               // (group) — organisational only
+  if (/^@/.test(seg)) return null;                     // @slot — parallel route
+  if (/^\[\[\.\.\..+\]\]$/.test(seg)) return `*${seg.slice(5, -2)}?`; // [[...rest]]
+  if (/^\[\.\.\..+\]$/.test(seg)) return `*${seg.slice(4, -1)}`;      // [...rest]
+  if (/^\[.+\]$/.test(seg)) return `:${seg.slice(1, -1)}`;            // [id]
+  return seg;
+}
+
+function buildRouteTable(data) {
+  // Derive the app dir from the MAP's own file list rather than the filesystem:
+  // the map already honours .gitignore and the ignore rules, so a build artefact
+  // or an untracked scratch file under app/ can never become a phantom route.
+  const keys = Object.keys(data.files);
+  const appDir = ["app", "src/app"].find((d) => keys.some((p) => p.startsWith(`${d}/`) && ROUTE_FILE_RE.test(p)));
+  if (!appDir) return null;                            // not an App Router project
+  const files = keys.filter((p) => p.startsWith(`${appDir}/`) && ROUTE_FILE_RE.test(p));
+  const layouts = new Map();
+  for (const f of files) if (/(^|\/)layout\.(t|j)sx?$/.test(f)) layouts.set(f.replace(/(^|\/)layout\.(t|j)sx?$/, ""), f);
+  const routes = [];
+  for (const f of files) {
+    const kind = /(^|\/)page\./.test(f) ? "page" : /(^|\/)route\./.test(f) ? "route" : null;
+    if (!kind) continue;                               // layout.tsx is chain-only, never its own URL
+    const relDir = f.slice(appDir.length + 1).replace(/(^|\/)(page|route)\.(t|j)sx?$/, "");
+    const segs = relDir === "" ? [] : relDir.split("/");
+    const url = "/" + segs.map(routeSegment).filter((s) => s !== null).join("/");
+    let src = ""; try { src = readFileSync(f, "utf8"); } catch {}
+    const methods = kind === "route"
+      ? HTTP_METHODS.filter((m) => new RegExp(`export\\s+(async\\s+)?(function|const)\\s+${m}\\b`).test(src))
+      : null;
+    // `export { default } from "X"` — a shim route that renders another route's
+    // component. A convention-only extractor misses these entirely because there
+    // is no `export default function` to match.
+    const alias = src.match(/export\s*\{\s*default(?:\s+as\s+default)?\s*\}\s*from\s*["']([^"']+)["']/)?.[1] ?? null;
+    // Layout chain: every ancestor dir INCLUDING (group) dirs — the groups that
+    // vanish from the URL are exactly the ones that add a layout.
+    //
+    // PAGES ONLY. A route.ts handler is not wrapped by layout.tsx — layouts are
+    // React components composing a rendered tree, and an API handler returns a
+    // Response, never JSX. Reporting a layout chain for /api/* would be a
+    // confident falsehood about what runs on that request.
+    const chain = [];
+    if (kind === "page") {
+      let cur = f.replace(/(^|\/)(page)\.(t|j)sx?$/, "");
+      for (;;) {
+        if (layouts.has(cur)) chain.unshift(layouts.get(cur));
+        if (!cur || cur === appDir) break;
+        const up = cur.slice(0, cur.lastIndexOf("/"));
+        if (up.length < appDir.length) break;
+        cur = up === cur ? "" : up;
+      }
+    }
+    routes.push({
+      url: url.length > 1 ? url.replace(/\/+$/, "") : "/",
+      kind, file: f,
+      ...(methods ? { methods } : {}),
+      ...(alias ? { alias } : {}),
+      layoutChain: chain,
+      boundary: data.files[f]?.rsc ?? null,
+    });
+  }
+  routes.sort((a, b) => (a.url < b.url ? -1 : a.url > b.url ? 1 : (a.kind < b.kind ? -1 : 1)));
+  return routes;
+}
+
+// Match a concrete URL against the table, honouring dynamic segments.
+function matchRoute(routes, q) {
+  const norm = (u) => ("/" + u.replace(/^\/+|\/+$/g, "")).replace(/\/+/g, "/");
+  const direct = routes.filter((r) => r.url === norm(q) || r.file === q || r.file.endsWith(`/${q}`));
+  if (direct.length) return direct;
+  const parts = norm(q).split("/").filter(Boolean);
+  return routes.filter((r) => {
+    const rp = r.url.split("/").filter(Boolean);
+    if (rp.some((s) => s.startsWith("*"))) {
+      const fixed = rp.filter((s) => !s.startsWith("*"));
+      return fixed.every((s, i) => s.startsWith(":") || s === parts[i]);
+    }
+    if (rp.length !== parts.length) return false;
+    return rp.every((s, i) => s.startsWith(":") || s === parts[i]);
+  });
 }
 
 // Resolve the named function/class that lexically encloses a reference node.

--- a/agentmap.mjs
+++ b/agentmap.mjs
@@ -33,6 +33,15 @@ const MAP = ".claude/agentmap/map.json";
 const MAP_LEGACY = ".claude/agentmap.json"; // pre-namespacing path; read for migration
 const MAP_DIRTY = ".claude/agentmap/map.dirty.json"; // dirty-tree build cache, keyed by dirtyFingerprint (Batch 3 Tier 1)
 const FACTS = ".claude/agentmap/facts.json"; // raw per-file facts snapshot for incremental rebuild (Batch 3 Tier 2)
+// Call-edge index, written ONLY by `--build-edges` (which the post-commit hook
+// runs in the background). Deliberately a SEPARATE file from map.json, not a new
+// field on it: building it costs ~4x a normal build (the type-checker's
+// go-to-definition per call site is irreducible — measured 5.9s vs 1.5s on a
+// 250-file repo even after prefiltering), and every other command
+// (--relates/--find/--hubs/--map) must not pay that. A missing or stale sidecar
+// is never an error: --callers silently falls back to the live ts-morph walk it
+// has always used, so this is a pure speedup with no new failure mode.
+const EDGES = ".claude/agentmap/calledges.json";
 // Bumped 2 → 3: Vue SFC support. `.vue` files now appear in the map and the
 // source-discovery / freshness checks treat them as first-class source files.
 // Bumped 3 → 4: per-file `locals` (non-exported top-level declarations) now
@@ -2855,6 +2864,11 @@ Maintenance:
                        wire .claude/settings.json (--dry-run = preview, no writes)
   --install-skill [--platform claude|cursor|codex|opencode|gemini|antigravity|copilot|agents|all] [--project|--global] [--dry-run]
                        install skills + always-on docs/hooks per platform
+  --build-edges        precompute the call-edge index so --callers answers from
+                       cache (~35ms) instead of a live type-checker walk (~1.5s).
+                       Costs ~4x a normal build, so it is explicit: the
+                       post-commit hook runs it in the background. Safe to skip —
+                       --callers falls back to the live walk without it.
   --hook-status          report whether agentmap git/nudge wiring is installed
   --doctor             read-only health report: hooks, skills/rules, MCP wiring, map cache
                          (exits 0, suggests fix commands, never writes files)
@@ -2899,7 +2913,7 @@ async function main() {
   const KNOWN = new Set([
     "--json", "--include-dts", "--no-locals", "--print",
     "--help", "-h", "--version", "-v", "--install-hooks", "--hook-status", "--doctor", "--install-skill", "--platform", "--project", "--global",
-    "--dry-run", "--setup-mcp", "--mcp",
+    "--dry-run", "--setup-mcp", "--mcp", "--build-edges",
     "--any", "--find", "--search", "--relates", "--callers", "--calls", "--in", "--depth", "--map", "--export", "--focus", "--tokens",
     "--symbols", "--feature", "--features", "--hubs",
   ]);
@@ -2942,7 +2956,7 @@ async function main() {
   const COMMANDS = {
     "--mcp": [], "--install-hooks": ["--dry-run"],
     "--install-skill": ["--platform", "--project", "--global", "--dry-run"],
-    "--hook-status": [], "--doctor": [], "--setup-mcp": ["--dry-run"],
+    "--hook-status": [], "--doctor": [], "--setup-mcp": ["--dry-run"], "--build-edges": [],
     "--any": [], "--find": [], "--search": [], "--relates": [], "--callers": ["--in", "--depth"], "--calls": ["--in", "--depth"], "--map": ["--focus", "--tokens"], "--export": ["--focus"],
     "--symbols": [], "--feature": [], "--features": [], "--hubs": [], "--print": [],
   };
@@ -3010,6 +3024,20 @@ async function main() {
   else if (has("--hook-status")) {
     try { hookStatus(); process.exit(0); }
     catch (e) { console.error(`agentmap --hook-status failed: ${e?.message || e}`); process.exit(3); }
+  }
+  // --build-edges: precompute the call-edge sidecar that --callers reads. Explicit
+  // (never implicit) because it costs ~4x a normal build — the post-commit hook
+  // runs it in the background so no interactive query ever waits on it.
+  else if (has("--build-edges")) {
+    try {
+      const r = buildCallEdges();
+      if (wantJson) console.log(JSON.stringify({ command: "build-edges", ...r }));
+      else console.log(`agentmap: ${r.edges} call edges from ${r.sites} sites across ${r.files} files → ${EDGES}`);
+      process.exit(0);
+    } catch (e) {
+      console.error(`agentmap --build-edges failed: ${e?.message || e}`);
+      process.exit(3);
+    }
   }
   // --doctor: read-only harness health report (hooks + skills + MCP + map cache).
   // Always exits 0; never writes. --json emits the structured report.
@@ -3472,6 +3500,130 @@ function invocationOf(id, SyntaxKind) {
   return null;
 }
 
+// Resolve the named function/class that lexically encloses a reference node.
+// Module scope because BOTH the live callGraph() walk and the sidecar sweep must
+// name callers identically — a second copy would drift and make the two paths
+// disagree. An anonymous callback (`.map(x => <Foo/>)`, an IIFE,
+// `startTransition(async () => …)`) is NOT an answer — it has no name worth
+// printing and no findReferences-able node to recurse on — so keep walking OUTWARD
+// until a named owner appears rather than giving up at the first anonymous
+// ancestor. Returns `{name, node}`: `node` is what the transitive BFS recurses on
+// (null when the owner cannot be recursed on); "<module>" means genuinely
+// top-level, not merely "wrapped in a callback".
+function enclosingOwner(id, SyntaxKind) {
+  let cur = id;
+  for (;;) {
+    const enc = cur.getFirstAncestor((an) => /Function|Method|Constructor|ClassDeclaration/.test(an.getKindName()));
+    if (!enc) return { name: "<module>", node: null };
+    const k = enc.getKindName();
+    if (k === "Constructor") {
+      const cls = enc.getFirstAncestorByKind(SyntaxKind.ClassDeclaration);
+      if (cls?.getName?.()) return { name: cls.getName(), node: cls };
+    } else if (/ArrowFunction|FunctionExpression/.test(k)) {
+      const p = enc.getParent();
+      const pk = p?.getKind?.();
+      // `const Foo = () => …` / `const Foo = function () {…}`
+      if (pk === SyntaxKind.VariableDeclaration && p.getInitializer?.() === enc
+        && p.getNameNode?.().getKind?.() === SyntaxKind.Identifier) return { name: p.getName(), node: p.getNameNode() };
+      // `{ foo: () => … }`
+      if (pk === SyntaxKind.PropertyAssignment && p.getName?.()) return { name: p.getName(), node: null };
+      // named function expression: `foo(function bar() {…})`
+      if (enc.getName?.()) return { name: enc.getName(), node: null };
+    } else if (enc.getName?.()) {
+      return { name: enc.getName(), node: enc };
+    }
+    cur = enc; // anonymous / unnamed — keep walking outward
+  }
+}
+const enclosingName = (id, SyntaxKind) => enclosingOwner(id, SyntaxKind).name;
+
+// Identity of the map a sidecar was derived from. ensureFresh() can return a map
+// keyed three different ways (clean HEAD / dirty fingerprint / non-git source
+// fingerprint); fold all of them plus the schema into one string so ANY drift
+// yields a different key and a stale sidecar is simply ignored. Cheap and
+// conservative on purpose: a false "stale" costs one live query, a false "fresh"
+// would serve wrong answers.
+function edgeKey(data) {
+  return [
+    SCHEMA_VERSION,
+    data.generatedSha || "",
+    data.dirtyFingerprint || "",
+    data.fingerprint || "",
+    data.dirty ?? "",
+  ].join(":");
+}
+
+// Read the sidecar, or null when it is absent / unreadable / keyed to a different
+// map. Never throws: every failure means "fall back to the live walk".
+function readCallEdges(data) {
+  if (!existsSync(EDGES)) return null;
+  try {
+    const c = JSON.parse(readFileSync(EDGES, "utf8"));
+    if (c.schema !== SCHEMA_VERSION || c.key !== edgeKey(data)) return null;
+    return Array.isArray(c.edges) ? c.edges : null;
+  } catch { return null; }
+}
+
+// Sweep every in-project file once and record every resolvable call/JSX site.
+//
+// This is the SAME resolution primitive the live --callers query uses, run from
+// the call-site side instead of per-symbol: "this site resolves to that
+// declaration" and "that declaration's references include this site" describe the
+// same edge, so one whole-repo pass yields what N per-symbol findReferences()
+// walks would, minus the per-query cost. Expensive (getDefinitionNodes() per
+// site) — which is exactly why it is a background/explicit step, never implicit.
+function buildCallEdges() {
+  const data = ensureFresh();
+  const { SyntaxKind } = tsMorph();
+  const { project, vueMap } = makeProject();
+  const cwd = process.cwd().replace(/\\/g, "/");
+  const rel = (p) => { const abs = p.replace(/\\/g, "/"); return (vueMap[abs] || abs).replace(cwd + "/", ""); };
+  const inProject = (k) => Object.prototype.hasOwnProperty.call(data.files, k);
+  const edges = [];
+  let sites = 0;
+  for (const sf of project.getSourceFiles()) {
+    const fp = sf.getFilePath().replace(/\\/g, "/");
+    if (fp.includes("/node_modules/") || fp.includes("/.next/")) continue;
+    const callerFile = rel(fp);
+    if (!inProject(callerFile)) continue;
+    for (const site of [
+      ...sf.getDescendantsOfKind(SyntaxKind.CallExpression),
+      ...sf.getDescendantsOfKind(SyntaxKind.NewExpression),
+      ...sf.getDescendantsOfKind(SyntaxKind.JsxSelfClosingElement),
+      ...sf.getDescendantsOfKind(SyntaxKind.JsxOpeningElement),
+    ]) {
+      sites++;
+      const k = site.getKind();
+      const isJsx = k === SyntaxKind.JsxSelfClosingElement || k === SyntaxKind.JsxOpeningElement;
+      const callee = isJsx ? site.getTagNameNode() : site.getExpression();
+      // Same shapes invocationOf() accepts: a bare identifier, or the name half of
+      // a dotted access (`ns.foo()` and `<UI.Widget />` alike — TypeScript models
+      // both as PropertyAccessExpression).
+      let idNode = null;
+      if (callee.getKind() === SyntaxKind.Identifier) idNode = callee;
+      else if (callee.getKind() === SyntaxKind.PropertyAccessExpression) idNode = callee.getNameNode();
+      if (!idNode) continue; // computed / parenthesized / dynamic — the same honest limit --calls has
+      let targets;
+      try { targets = idNode.getDefinitionNodes?.() || []; } catch { continue; }
+      const callerLine = idNode.getStartLineNumber();
+      const callerName = enclosingName(idNode, SyntaxKind);
+      for (const d of targets) {
+        const tsf = d.getSourceFile();
+        if (tsf.isInNodeModules() || tsf.isDeclarationFile()) continue;
+        const calleeFile = rel(tsf.getFilePath().replace(/\\/g, "/"));
+        if (!inProject(calleeFile)) continue;
+        const calleeName = d.getName?.() ?? idNode.getText();
+        edges.push({ callerFile, callerLine, callerName, calleeFile, calleeName, kind: isJsx ? "jsx" : "call" });
+      }
+    }
+  }
+  mkdirSync(".claude/agentmap", { recursive: true });
+  const tmp = `${EDGES}.${process.pid}.tmp`; // PID-suffixed for the same reason assemble() is
+  writeFileSync(tmp, JSON.stringify({ schema: SCHEMA_VERSION, key: edgeKey(data), edges }));
+  renameSync(tmp, EDGES);
+  return { files: Object.keys(data.files).length, sites, edges: edges.length };
+}
+
 function callGraph(symbolName, { inFilter = "", direction = "callers", depth = 1 } = {}) {
   // --depth N (default 1) makes the query TRANSITIVE. depth 1 is byte-identical to
   // the single-hop path below (guarded `if (maxDepth > 1)`); depth ≥2 runs a capped
@@ -3512,6 +3664,36 @@ function callGraph(symbolName, { inFilter = "", direction = "callers", depth = 1
   if (!owners.length) return { command: direction, query: symbolName, error: "no match", candidates: [], _code: 1 };
   if (owners.length > 1) return { command: direction, query: symbolName, error: "ambiguous", candidates: owners, _code: 1 };
   const fileKey = owners[0];
+  // Phase B FAST PATH — answer from the prebuilt call-edge sidecar when one exists
+  // for exactly this map. Skips tsMorph() + makeProject() + the checker's
+  // full-program bind entirely (~1.5s -> ~35ms measured on a 250-400 file repo).
+  // Deliberately narrow: single-hop --callers only. --calls has a different output
+  // shape and --depth >= 2 needs findReferences-able NODES to recurse on, which a
+  // JSON row cannot carry; both keep the live walk. A missing/stale sidecar just
+  // falls through, so this can only ever be faster, never wrong.
+  if (direction === "callers" && maxDepth === 1) {
+    const cached = readCallEdges(data);
+    if (cached) {
+      const seen = new Set();
+      const sites = [];
+      for (const e of cached) {
+        if (e.calleeFile !== fileKey || e.calleeName !== symbolName) continue;
+        const dedupe = `${e.callerFile}:${e.callerLine}`; // same key the live walk dedupes on
+        if (seen.has(dedupe)) continue;
+        seen.add(dedupe);
+        sites.push({ file: e.callerFile, line: e.callerLine, caller: e.callerName });
+      }
+      sites.sort((x, y) =>
+        ((data.files[y.file]?.pagerank ?? 0) - (data.files[x.file]?.pagerank ?? 0))
+        || (x.file < y.file ? -1 : x.file > y.file ? 1 : x.line - y.line));
+      const shown = sites.slice(0, SYMBOL_MATCH_LIMIT);
+      return {
+        command: "callers", query: symbolName, symbol: symbolName, file: fileKey,
+        total: sites.length, shown: shown.length, truncated: sites.length > shown.length,
+        callers: shown, _code: sites.length ? 0 : 1,
+      };
+    }
+  }
   // Phase B — LAZY full Project (inc=null ⇒ language service live; NEVER the
   // incremental branch, which loads other files as empty stubs and would hide
   // cross-file callers). tsMorph() is the ~105ms init, fired only here.
@@ -3659,39 +3841,8 @@ function callGraph(symbolName, { inFilter = "", direction = "callers", depth = 1
   // is. This is the compiler-accuracy line — a type-position mention, a re-export, a
   // bare value reference, or a same-named local in another file binds to a DIFFERENT
   // symbol and never reaches here.
-  // Resolve the named function/class that lexically encloses a call site. Shared by
-  // the single-hop and the transitive path. An anonymous callback (`.map(x => <Foo/>)`,
-  // an IIFE, `startTransition(async () => …)`) is NOT an answer — it has no name worth
-  // printing and no findReferences-able node to recurse on — so keep walking OUTWARD
-  // until a named owner appears rather than giving up at the first anonymous ancestor.
-  // `node` is the findReferences-able node for the BFS to recurse on (null when the
-  // owner cannot be recursed on); `name` is what gets printed. "<module>" now means
-  // genuinely top-level, not merely "wrapped in a callback".
-  const enclosing = (id) => {
-    let cur = id;
-    for (;;) {
-      const enc = cur.getFirstAncestor((an) => /Function|Method|Constructor|ClassDeclaration/.test(an.getKindName()));
-      if (!enc) return { name: "<module>", node: null };
-      const k = enc.getKindName();
-      if (k === "Constructor") {
-        const cls = enc.getFirstAncestorByKind(SyntaxKind.ClassDeclaration);
-        if (cls?.getName?.()) return { name: cls.getName(), node: cls };
-      } else if (/ArrowFunction|FunctionExpression/.test(k)) {
-        const p = enc.getParent();
-        const pk = p?.getKind?.();
-        // `const Foo = () => …` / `const Foo = function () {…}`
-        if (pk === SyntaxKind.VariableDeclaration && p.getInitializer?.() === enc
-          && p.getNameNode?.().getKind?.() === SyntaxKind.Identifier) return { name: p.getName(), node: p.getNameNode() };
-        // `{ foo: () => … }`
-        if (pk === SyntaxKind.PropertyAssignment && p.getName?.()) return { name: p.getName(), node: null };
-        // named function expression: `foo(function bar() {…})`
-        if (enc.getName?.()) return { name: enc.getName(), node: null };
-      } else if (enc.getName?.()) {
-        return { name: enc.getName(), node: enc };
-      }
-      cur = enc; // anonymous / unnamed — keep walking outward
-    }
-  };
+  // Shared with the sidecar sweep — see enclosingOwner() at module scope.
+  const enclosing = (id) => enclosingOwner(id, SyntaxKind);
   if (maxDepth > 1) {
     // Transitive INCOMING BFS: to recurse UP one hop we need a findReferences-able
     // node for the ENCLOSING symbol of each call site — that is `enclosing().node`

--- a/hooks/post-commit
+++ b/hooks/post-commit
@@ -127,9 +127,21 @@ _am_descendants() {
   printf '%s' "$_am_all"
 }
 
+# After the map, precompute the call-edge index so `--callers` answers from cache
+# (~77ms) instead of a live type-checker walk (~1500ms). It is a SEPARATE step
+# because it costs ~4x a map rebuild (~9s on 250 files) — acceptable here, where
+# it is detached, lock-guarded and timeout-capped and no one is waiting, but not
+# acceptable inline on an interactive query. Set AGENTMAP_HOOK_EDGES=0 to skip it
+# (on a very large repo, or to keep post-commit CPU to a minimum); --callers then
+# simply falls back to the live walk, which is what it has always done.
+_am_edges() {
+  [ "${AGENTMAP_HOOK_EDGES:-1}" = "1" ] || return 0
+  $RUNNER --build-edges
+}
+
 (
   cd "$ROOT" || { rmdir "$LOCK" 2>/dev/null; exit 0; }
-  $RUNNER >/dev/null 2>&1 &
+  { $RUNNER && _am_edges; } >/dev/null 2>&1 &
   _am_pid=$!
   # SIGTERM first so a healthy run can flush and exit; SIGKILL only if it ignores
   # it. A pid could in principle be recycled inside that 5s window; the exposure

--- a/test/call-edges-sidecar.test.mjs
+++ b/test/call-edges-sidecar.test.mjs
@@ -21,7 +21,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { existsSync, readFileSync, writeFileSync, renameSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
-import { makeRepo, gitInit, run, cleanup } from "./helpers.mjs";
+import { makeRepo, gitInit, run, runErr, cleanup } from "./helpers.mjs";
 
 const EDGES = ".claude/agentmap/calledges.json";
 
@@ -146,12 +146,16 @@ test("a CORRUPT sidecar falls back to the live walk instead of crashing", () => 
     gitInit(dir, { commit: true });
     run(dir, "--build-edges");
     writeFileSync(join(dir, EDGES), "{ this is not json");
-    const r = run(dir, "--callers", "target", "--in", "src/target.ts", "--json");
+    const r = runErr(dir, "--callers", "target", "--in", "src/target.ts", "--json");
     assert.equal(r.status, 0, r.stderr);
     assert.equal(JSON.parse(r.stdout).total, 2);
-    // Truncated-but-valid JSON with the wrong shape must also fall back.
-    writeFileSync(join(dir, EDGES), JSON.stringify({ schema: 999, key: "nope", edges: "not-an-array" }));
-    assert.equal(JSON.parse(run(dir, "--callers", "target", "--in", "src/target.ts", "--json").stdout).total, 2);
+    // ...and SAYS so. Staleness is routine and stays quiet, but silently serving a
+    // 20x-slower path because the cache is corrupt is undiagnosable.
+    assert.match(r.stderr, /unreadable|malformed/, "a corrupt sidecar must be reported on stderr");
+    // Valid JSON with the wrong shape must also fall back, and also say so.
+    const r2 = runErr(dir, "--callers", "target", "--in", "src/target.ts", "--json");
+    assert.equal(JSON.parse(r2.stdout).total, 2);
+    assert.match(r2.stderr, /unreadable|malformed/, "a malformed sidecar must be reported too");
   } finally { cleanup(dir); }
 });
 

--- a/test/call-edges-sidecar.test.mjs
+++ b/test/call-edges-sidecar.test.mjs
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: MIT
+// ============================================================================
+//  Call-edge sidecar (--build-edges) — a CACHE, never a second source of truth.
+//
+//  `--callers` has always answered from a live ts-morph reference walk: correct,
+//  and ~1500ms because the type-checker's first full-program bind dominates
+//  (~750ms) and is paid per query. `--build-edges` precomputes the same edges
+//  once into .claude/agentmap/calledges.json so the query becomes a JSON lookup
+//  (~77ms measured on a 250-file repo).
+//
+//  The whole design rests on ONE invariant, which is what this file pins:
+//  a cached answer is BYTE-IDENTICAL to the live answer, and anything that could
+//  make it otherwise (a stale key, a corrupt file, a query shape the sidecar
+//  cannot represent) falls back to the live walk instead of guessing. A cache
+//  that can disagree with its source is worse than no cache, so every test here
+//  compares the two paths directly rather than asserting a hardcoded shape.
+//
+//  Run: node --test test/call-edges-sidecar.test.mjs
+// ============================================================================
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, readFileSync, writeFileSync, renameSync, unlinkSync } from "node:fs";
+import { join } from "node:path";
+import { makeRepo, gitInit, run, cleanup } from "./helpers.mjs";
+
+const EDGES = ".claude/agentmap/calledges.json";
+
+// A repo exercising the shapes the sidecar has to round-trip: a plain call, a
+// JSX component (self-closing AND paired), a dotted `<UI.Widget />` tag, a call
+// inside an anonymous .map() callback (enclosing-name resolution), and a decoy
+// file with its OWN private `target` that must never be attributed.
+function repo() {
+  return {
+    "tsconfig.json": JSON.stringify({
+      compilerOptions: { jsx: "react-jsx", moduleResolution: "bundler", module: "esnext", target: "esnext", baseUrl: "." },
+    }),
+    "src/target.ts": "export function target() { return 42; }\n",
+    "src/Widget.tsx": "export function Widget(p: { id?: string }) { return <div>{p.id}</div>; }\n",
+    "src/callers.ts":
+      'import { target } from "./target";\n' +
+      "export function runA() { return target(); }\n" +
+      "export function runB() { const v = target(); return v + 1; }\n",
+    "src/Uses.tsx":
+      'import { Widget } from "./Widget";\n' +
+      "export function Plain() { return <Widget />; }\n" +
+      "export function Paired() { return <Widget>x</Widget>; }\n" +
+      "export function Mapped({ ids }: { ids: string[] }) {\n" +
+      "  return <div>{ids.map((i) => <Widget key={i} id={i} />)}</div>;\n" +
+      "}\n",
+    "src/Dotted.tsx":
+      'import * as UI from "./Widget";\n' +
+      "export function Dotted() { return <UI.Widget />; }\n",
+    // Private same-named `target` — a DIFFERENT symbol. Never a caller of src/target.ts.
+    "src/decoy.ts":
+      "function target() { return 0; }\n" +
+      "export function useDecoy() { return target(); }\n",
+  };
+}
+
+// Capture --callers twice: once served from the sidecar, once with the sidecar
+// moved aside so the live walk runs. Returns [cached, live] stdout.
+function bothPaths(dir, ...args) {
+  const p = join(dir, EDGES);
+  assert.ok(existsSync(p), "sidecar should exist before comparing paths");
+  const cached = run(dir, ...args).stdout;
+  const bak = `${p}.bak`;
+  renameSync(p, bak);
+  const live = run(dir, ...args).stdout;
+  renameSync(bak, p);
+  return [cached, live];
+}
+
+test("--build-edges writes a sidecar and reports what it indexed", () => {
+  const dir = makeRepo(repo());
+  try {
+    gitInit(dir, { commit: true });
+    const r = run(dir, "--build-edges", "--json");
+    assert.equal(r.status, 0, r.stderr);
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.command, "build-edges");
+    assert.ok(out.edges > 0, `expected some edges, got ${out.edges}`);
+    assert.ok(out.sites >= out.edges, "sites walked cannot be fewer than edges resolved");
+    assert.ok(existsSync(join(dir, EDGES)), "sidecar file should exist");
+  } finally { cleanup(dir); }
+});
+
+test("cached --callers is byte-identical to the live walk", () => {
+  const dir = makeRepo(repo());
+  try {
+    gitInit(dir, { commit: true });
+    run(dir, "--build-edges");
+    for (const q of [
+      ["--callers", "target", "--in", "src/target.ts"],
+      ["--callers", "Widget", "--in", "src/Widget.tsx"],
+      ["--callers", "target", "--in", "src/decoy.ts"],
+    ]) {
+      const [cached, live] = bothPaths(dir, ...q, "--json");
+      assert.equal(cached, live, `sidecar diverged from live for: ${q.join(" ")}`);
+    }
+  } finally { cleanup(dir); }
+});
+
+test("the decoy's private target is never attributed to the exported one", () => {
+  const dir = makeRepo(repo());
+  try {
+    gitInit(dir, { commit: true });
+    run(dir, "--build-edges");
+    const out = JSON.parse(run(dir, "--callers", "target", "--in", "src/target.ts", "--json").stdout);
+    const files = out.callers.map((c) => c.file);
+    assert.ok(!files.includes("src/decoy.ts"), `decoy leaked into callers: ${JSON.stringify(files)}`);
+    assert.equal(out.total, 2, "runA + runB are the only real callers");
+  } finally { cleanup(dir); }
+});
+
+test("a paired <Widget>…</Widget> counts once, and .map() callers are named", () => {
+  const dir = makeRepo(repo());
+  try {
+    gitInit(dir, { commit: true });
+    run(dir, "--build-edges");
+    const out = JSON.parse(run(dir, "--callers", "Widget", "--in", "src/Widget.tsx", "--json").stdout);
+    const lines = out.callers.map((c) => `${c.file}:${c.line}`);
+    assert.equal(new Set(lines).size, lines.length, "closing tags must not double-count");
+    const mapped = out.callers.find((c) => c.file === "src/Uses.tsx" && c.caller === "Mapped");
+    assert.ok(mapped, `.map() call site should be attributed to Mapped, got ${JSON.stringify(out.callers)}`);
+  } finally { cleanup(dir); }
+});
+
+test("a STALE sidecar is ignored, not served", () => {
+  const dir = makeRepo(repo());
+  try {
+    gitInit(dir, { commit: true });
+    run(dir, "--build-edges");
+    const before = JSON.parse(run(dir, "--callers", "target", "--in", "src/target.ts", "--json").stdout);
+    assert.equal(before.total, 2);
+    // Add a third caller WITHOUT rebuilding edges. The sidecar still claims 2.
+    writeFileSync(join(dir, "src/callerC.ts"),
+      'import { target } from "./target";\nexport function runC() { return target(); }\n');
+    const after = JSON.parse(run(dir, "--callers", "target", "--in", "src/target.ts", "--json").stdout);
+    assert.equal(after.total, 3, "a stale sidecar must not mask a new call site");
+  } finally { cleanup(dir); }
+});
+
+test("a CORRUPT sidecar falls back to the live walk instead of crashing", () => {
+  const dir = makeRepo(repo());
+  try {
+    gitInit(dir, { commit: true });
+    run(dir, "--build-edges");
+    writeFileSync(join(dir, EDGES), "{ this is not json");
+    const r = run(dir, "--callers", "target", "--in", "src/target.ts", "--json");
+    assert.equal(r.status, 0, r.stderr);
+    assert.equal(JSON.parse(r.stdout).total, 2);
+    // Truncated-but-valid JSON with the wrong shape must also fall back.
+    writeFileSync(join(dir, EDGES), JSON.stringify({ schema: 999, key: "nope", edges: "not-an-array" }));
+    assert.equal(JSON.parse(run(dir, "--callers", "target", "--in", "src/target.ts", "--json").stdout).total, 2);
+  } finally { cleanup(dir); }
+});
+
+test("query shapes the sidecar cannot represent still use the live walk", () => {
+  const dir = makeRepo(repo());
+  try {
+    gitInit(dir, { commit: true });
+    run(dir, "--build-edges");
+    // --depth >= 2 needs findReferences-able NODES to recurse on; --calls is the
+    // opposite direction with a different output shape. Both must keep working.
+    const [d2c, d2l] = bothPaths(dir, "--callers", "target", "--in", "src/target.ts", "--depth", "2", "--json");
+    assert.equal(d2c, d2l, "--depth 2 must not be served from the sidecar");
+    const [cc, cl] = bothPaths(dir, "--calls", "runA", "--in", "src/callers.ts", "--json");
+    assert.equal(cc, cl, "--calls must not be served from the sidecar");
+  } finally { cleanup(dir); }
+});
+
+test("no sidecar is a normal state — --callers works untouched", () => {
+  const dir = makeRepo(repo());
+  try {
+    gitInit(dir, { commit: true });
+    assert.ok(!existsSync(join(dir, EDGES)), "no sidecar should exist before --build-edges");
+    const r = run(dir, "--callers", "target", "--in", "src/target.ts", "--json");
+    assert.equal(r.status, 0, r.stderr);
+    assert.equal(JSON.parse(r.stdout).total, 2);
+  } finally { cleanup(dir); }
+});
+
+test("LAZY: normal commands neither read nor write the sidecar", () => {
+  const dir = makeRepo(repo());
+  try {
+    gitInit(dir, { commit: true });
+    for (const cmd of [["--relates", "src/target.ts"], ["--find", "target"], ["--hubs"], ["--map"]]) {
+      run(dir, ...cmd);
+      assert.ok(!existsSync(join(dir, EDGES)), `${cmd[0]} must not build the sidecar`);
+    }
+  } finally { cleanup(dir); }
+});

--- a/test/call-edges-sidecar.test.mjs
+++ b/test/call-edges-sidecar.test.mjs
@@ -247,6 +247,23 @@ test("a reassigned local alias does not fabricate a call to the original", () =>
   } finally { cleanup(dir); }
 });
 
+// A sidecar written by an older agentmap whose edge ROWS meant something
+// different must not be served: a missing edge is indistinguishable from "no
+// caller", so the failure would be a confident wrong answer with no symptom.
+test("a sidecar from a different edge format is not served", () => {
+  const dir = makeRepo(repo());
+  try {
+    gitInit(dir, { commit: true });
+    run(dir, "--build-edges");
+    const p = join(dir, EDGES);
+    const c = JSON.parse(readFileSync(p, "utf8"));
+    // Same map, older row format — the key must not match.
+    writeFileSync(p, JSON.stringify({ ...c, key: c.key.replace(/e\d+/, "e1"), edges: [] }));
+    const out = JSON.parse(run(dir, "--callers", "target", "--in", "src/target.ts", "--json").stdout);
+    assert.equal(out.total, 2, "an old-format sidecar must be ignored, not believed");
+  } finally { cleanup(dir); }
+});
+
 test("LAZY: normal commands neither read nor write the sidecar", () => {
   const dir = makeRepo(repo());
   try {

--- a/test/call-edges-sidecar.test.mjs
+++ b/test/call-edges-sidecar.test.mjs
@@ -180,6 +180,69 @@ test("no sidecar is a normal state — --callers works untouched", () => {
   } finally { cleanup(dir); }
 });
 
+// ---------------------------------------------------------------------------
+// Regressions found by adversarially diffing the two paths against each other.
+// Each of these produced FAST != LIVE (or a wrong answer in BOTH) before the fix.
+// ---------------------------------------------------------------------------
+
+// `new Foo()` is an invocation. invocationOf() only matched CallExpression, so a
+// class reachable ONLY via `new` reported ZERO callers — a silent wrong answer,
+// exit 1, indistinguishable from genuinely unused. Independent of the sidecar:
+// the live walk had this bug on its own, and so did --depth >= 2.
+test("new Foo() is a call site (live walk, no sidecar)", () => {
+  const dir = makeRepo({
+    "src/widget.ts": "export class Foo { method() { return 1; } }\n",
+    "src/consumer.ts":
+      'import { Foo } from "./widget";\n' +
+      "export function App() { const o = new Foo(); return o; }\n",
+  });
+  try {
+    gitInit(dir, { commit: true });
+    assert.ok(!existsSync(join(dir, EDGES)), "this asserts the LIVE path");
+    const out = JSON.parse(run(dir, "--callers", "Foo", "--in", "src/widget.ts", "--json").stdout);
+    assert.equal(out.total, 1, `new Foo() must count as a caller, got ${JSON.stringify(out.callers)}`);
+    assert.equal(out.callers[0].caller, "App");
+  } finally { cleanup(dir); }
+});
+
+// `export { impl as Widget }` binds the export to `Widget` while the declaration
+// node is still named `impl`. Phase A resolves the query by EXPORTED name, so
+// keying sidecar edges on the node's own name made the symbol look uncalled.
+test("a symbol exported under a different name than its declaration", () => {
+  const dir = makeRepo({
+    "tsconfig.json": JSON.stringify({ compilerOptions: { jsx: "react-jsx", moduleResolution: "bundler", module: "esnext", target: "esnext", baseUrl: "." } }),
+    "src/widget.ts": "function impl() { return 1; }\nexport { impl as Widget };\n",
+    "src/consumer.ts": 'import { Widget } from "./widget";\nexport function App() { return Widget(); }\n',
+  });
+  try {
+    gitInit(dir, { commit: true });
+    run(dir, "--build-edges");
+    const [cached, live] = bothPaths(dir, "--callers", "Widget", "--in", "src/widget.ts", "--json");
+    assert.equal(cached, live);
+    assert.equal(JSON.parse(cached).total, 1, "the aliased export has exactly one caller");
+  } finally { cleanup(dir); }
+});
+
+// go-to-definition walks THROUGH `const wrapped = helper` and returns both the
+// local binding and `helper`. Emitting every target credited `helper` with a call
+// site that never names it — which the live reference walk does not report.
+test("a reassigned local alias does not fabricate a call to the original", () => {
+  const dir = makeRepo({
+    "src/lib.ts": "export function helper() { return 1; }\n",
+    "src/consumer.ts":
+      'import { helper } from "./lib";\n' +
+      "const wrapped = helper;\n" +
+      "export function App() { return wrapped(); }\n",
+  });
+  try {
+    gitInit(dir, { commit: true });
+    run(dir, "--build-edges");
+    const [cached, live] = bothPaths(dir, "--callers", "helper", "--in", "src/lib.ts", "--json");
+    assert.equal(cached, live);
+    assert.equal(JSON.parse(cached).total, 0, "`wrapped()` names wrapped, not helper");
+  } finally { cleanup(dir); }
+});
+
 test("LAZY: normal commands neither read nor write the sidecar", () => {
   const dir = makeRepo(repo());
   try {

--- a/test/call-edges-sidecar.test.mjs
+++ b/test/call-edges-sidecar.test.mjs
@@ -159,17 +159,75 @@ test("a CORRUPT sidecar falls back to the live walk instead of crashing", () => 
   } finally { cleanup(dir); }
 });
 
-test("query shapes the sidecar cannot represent still use the live walk", () => {
+// The sidecar stores BOTH ends of every edge, so the same table answers the
+// opposite direction and the transitive walk — not just single-hop --callers.
+// Each of these must stay byte-identical to the live walk, which is the only
+// thing that makes serving them from cache legitimate.
+test("--calls is served from cache, byte-identical to the live walk", () => {
   const dir = makeRepo(repo());
   try {
     gitInit(dir, { commit: true });
     run(dir, "--build-edges");
-    // --depth >= 2 needs findReferences-able NODES to recurse on; --calls is the
-    // opposite direction with a different output shape. Both must keep working.
-    const [d2c, d2l] = bothPaths(dir, "--callers", "target", "--in", "src/target.ts", "--depth", "2", "--json");
-    assert.equal(d2c, d2l, "--depth 2 must not be served from the sidecar");
-    const [cc, cl] = bothPaths(dir, "--calls", "runA", "--in", "src/callers.ts", "--json");
-    assert.equal(cc, cl, "--calls must not be served from the sidecar");
+    for (const q of [
+      ["--calls", "runA", "--in", "src/callers.ts"],
+      ["--calls", "Mapped", "--in", "src/Uses.tsx"],
+      ["--calls", "useDecoy", "--in", "src/decoy.ts"],
+    ]) {
+      const [cached, live] = bothPaths(dir, ...q, "--json");
+      assert.equal(cached, live, `--calls diverged for: ${q.join(" ")}`);
+    }
+  } finally { cleanup(dir); }
+});
+
+test("--callers --depth N is served from cache, byte-identical (incl. the `via` chain)", () => {
+  const dir = makeRepo(repo());
+  try {
+    gitInit(dir, { commit: true });
+    run(dir, "--build-edges");
+    for (const d of ["2", "3", "5"]) {
+      const [cached, live] = bothPaths(dir, "--callers", "target", "--in", "src/target.ts", "--depth", d, "--json");
+      assert.equal(cached, live, `--depth ${d} diverged`);
+    }
+    // `via` is user-visible provenance: file:caller:DECLARATION-line. An internal
+    // dedup key leaking into it here would be invisible to a shape-only assertion.
+    const j = JSON.parse(run(dir, "--callers", "target", "--in", "src/target.ts", "--depth", "2", "--json").stdout);
+    for (const c of j.callers) {
+      if (c.via === null) continue;
+      assert.match(c.via, /^[^\s]+:[^:]+:\d+$/, `via must be file:caller:line, got ${JSON.stringify(c.via)}`);
+    }
+  } finally { cleanup(dir); }
+});
+
+test("outgoing rows tie-break by callee NAME, matching the live walk", () => {
+  const dir = makeRepo({
+    "src/z.ts": "export function alpha(){return 1;}\nexport function beta(){return 2;}\nexport function gamma(){return 3;}\n",
+    // Declared gamma-first so insertion order can't accidentally satisfy the sort.
+    "src/caller.ts":
+      'import { alpha, beta, gamma } from "./z";\n' +
+      "export function run(){ return gamma() + beta() + alpha(); }\n",
+  });
+  try {
+    gitInit(dir, { commit: true });
+    run(dir, "--build-edges");
+    const [cached, live] = bothPaths(dir, "--calls", "run", "--in", "src/caller.ts", "--json");
+    assert.equal(cached, live);
+    assert.deepEqual(JSON.parse(cached).calls.map((c) => c.name), ["alpha", "beta", "gamma"]);
+  } finally { cleanup(dir); }
+});
+
+test("a sidecar predating these fields is rejected, not half-read", () => {
+  const dir = makeRepo(repo());
+  try {
+    gitInit(dir, { commit: true });
+    run(dir, "--build-edges");
+    const p = join(dir, EDGES);
+    const c = JSON.parse(readFileSync(p, "utf8"));
+    // Old format: rows without calleeLine/calleeKind/callerDeclLine. Serving these
+    // would silently produce rows with `undefined` fields rather than falling back.
+    writeFileSync(p, JSON.stringify({ ...c, key: c.key.replace(/e\d+/, "e2") }));
+    const [_, live] = [null, run(dir, "--calls", "runA", "--in", "src/callers.ts", "--json").stdout];
+    assert.ok(JSON.parse(live).calls.every((x) => x.line !== undefined && x.kind !== undefined),
+      "an old-format sidecar must be ignored so the live walk fills these in");
   } finally { cleanup(dir); }
 });
 

--- a/test/routes.test.mjs
+++ b/test/routes.test.mjs
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: MIT
+// ============================================================================
+//  Next.js App Router route table (--routes / --route).
+//
+//  The bar is a URL you can paste into a browser. That is exactly where a
+//  convention-only extractor goes wrong: a `(group)` folder organises the tree
+//  and contributes NOTHING to the URL, but it DOES contribute a layout. A table
+//  that emits `/(app)/brands/:id` — a path that 404s — is worse than no table,
+//  because it looks authoritative. So every assertion here is about the URL
+//  being REAL, not merely about a route being found.
+//
+//  Run: node --test test/routes.test.mjs
+// ============================================================================
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { makeRepo, gitInit, run, cleanup } from "./helpers.mjs";
+
+const TSCONFIG = JSON.stringify({
+  compilerOptions: { jsx: "react-jsx", moduleResolution: "bundler", module: "esnext", target: "esnext", baseUrl: "." },
+});
+
+// Every App Router shape that changes a URL, in one repo.
+function repo() {
+  return {
+    "tsconfig.json": TSCONFIG,
+    "app/layout.tsx": "export default function Root({children}:{children:any}){ return <div>{children}</div>; }\n",
+    "app/page.tsx": "export default function Home(){ return <main/>; }\n",
+    // route GROUP: organisational, must NOT appear in the URL, but DOES add a layout
+    "app/(marketing)/layout.tsx": "export default function M({children}:{children:any}){ return <div>{children}</div>; }\n",
+    "app/(marketing)/about/page.tsx": "export default function About(){ return <main/>; }\n",
+    // dynamic + catch-all + optional catch-all
+    "app/blog/[slug]/page.tsx": "export default function Post(){ return <main/>; }\n",
+    "app/docs/[...path]/page.tsx": "export default function Docs(){ return <main/>; }\n",
+    "app/shop/[[...filter]]/page.tsx": "export default function Shop(){ return <main/>; }\n",
+    // API route with several methods — not a page, and NOT layout-wrapped
+    "app/api/items/route.ts":
+      "export async function GET(){ return new Response('a'); }\n" +
+      "export async function POST(){ return new Response('b'); }\n",
+    // re-export shim: no `export default function`, so a naive extractor misses it
+    "app/v2/about/page.tsx": 'export { default } from "@/app/(marketing)/about/page";\n',
+    // parallel-route slot: contributes no URL segment of its own
+    "app/dash/@side/page.tsx": "export default function Side(){ return <aside/>; }\n",
+  };
+}
+
+const json = (dir, ...a) => JSON.parse(run(dir, ...a, "--json").stdout);
+
+test("route groups are stripped from the URL but kept in the layout chain", () => {
+  const dir = makeRepo(repo());
+  try {
+    gitInit(dir, { commit: true });
+    const r = json(dir, "--routes");
+    const about = r.routes.find((x) => x.file === "app/(marketing)/about/page.tsx");
+    assert.equal(about.url, "/about", "a (group) folder must not appear in the URL");
+    assert.ok(!r.routes.some((x) => x.url.includes("(")), "no URL may contain a route group");
+    // ...but the group's layout still wraps it — that is the whole point of a group.
+    assert.deepEqual(about.layoutChain, ["app/layout.tsx", "app/(marketing)/layout.tsx"]);
+  } finally { cleanup(dir); }
+});
+
+test("dynamic, catch-all and optional-catch-all segments render as real params", () => {
+  const dir = makeRepo(repo());
+  try {
+    gitInit(dir, { commit: true });
+    const byFile = Object.fromEntries(json(dir, "--routes").routes.map((r) => [r.file, r.url]));
+    assert.equal(byFile["app/blog/[slug]/page.tsx"], "/blog/:slug");
+    assert.equal(byFile["app/docs/[...path]/page.tsx"], "/docs/*path");
+    assert.equal(byFile["app/shop/[[...filter]]/page.tsx"], "/shop/*filter?");
+    assert.ok(!Object.values(byFile).some((u) => /[\[\]]/.test(u)), "no raw brackets may survive into a URL");
+  } finally { cleanup(dir); }
+});
+
+test("the root page is / and not /page.tsx", () => {
+  const dir = makeRepo(repo());
+  try {
+    gitInit(dir, { commit: true });
+    const root = json(dir, "--routes").routes.find((r) => r.file === "app/page.tsx");
+    assert.equal(root.url, "/");
+  } finally { cleanup(dir); }
+});
+
+test("API routes carry their HTTP methods and are NOT layout-wrapped", () => {
+  const dir = makeRepo(repo());
+  try {
+    gitInit(dir, { commit: true });
+    const api = json(dir, "--routes").routes.find((r) => r.file === "app/api/items/route.ts");
+    assert.equal(api.kind, "route");
+    assert.deepEqual(api.methods, ["GET", "POST"]);
+    // A layout is a React component composing a tree; an API handler returns a
+    // Response and never renders. Claiming a layout chain here would be false.
+    assert.deepEqual(api.layoutChain, [], "route.ts is not wrapped by layout.tsx");
+  } finally { cleanup(dir); }
+});
+
+test("a re-export shim is a real route, aliased to its target", () => {
+  const dir = makeRepo(repo());
+  try {
+    gitInit(dir, { commit: true });
+    const shim = json(dir, "--routes").routes.find((r) => r.file === "app/v2/about/page.tsx");
+    assert.ok(shim, "`export { default } from` is still a routable page");
+    assert.equal(shim.url, "/v2/about");
+    assert.match(shim.alias, /about\/page$/);
+  } finally { cleanup(dir); }
+});
+
+test("a @slot parallel-route folder contributes no URL segment", () => {
+  const dir = makeRepo(repo());
+  try {
+    gitInit(dir, { commit: true });
+    const slot = json(dir, "--routes").routes.find((r) => r.file === "app/dash/@side/page.tsx");
+    assert.equal(slot.url, "/dash", "@slot is not a URL segment");
+  } finally { cleanup(dir); }
+});
+
+test("--route resolves a CONCRETE url through a dynamic segment", () => {
+  const dir = makeRepo(repo());
+  try {
+    gitInit(dir, { commit: true });
+    const m = json(dir, "--route", "/blog/hello-world").matches;
+    assert.equal(m.length, 1);
+    assert.equal(m[0].file, "app/blog/[slug]/page.tsx");
+    assert.deepEqual(m[0].layoutChain, ["app/layout.tsx"]);
+  } finally { cleanup(dir); }
+});
+
+test("--route also answers in reverse, from a file path", () => {
+  const dir = makeRepo(repo());
+  try {
+    gitInit(dir, { commit: true });
+    const m = json(dir, "--route", "app/(marketing)/about/page.tsx").matches;
+    assert.equal(m.length, 1);
+    assert.equal(m[0].url, "/about");
+  } finally { cleanup(dir); }
+});
+
+test("--route on an unknown url exits 1 with an empty match set", () => {
+  const dir = makeRepo(repo());
+  try {
+    gitInit(dir, { commit: true });
+    const r = run(dir, "--route", "/nope/nothing/here", "--json");
+    assert.equal(r.status, 1);
+    assert.deepEqual(JSON.parse(r.stdout).matches, []);
+  } finally { cleanup(dir); }
+});
+
+test("a repo with no app/ directory says so instead of inventing routes", () => {
+  const dir = makeRepo({ "src/index.ts": "export const a = 1;\n" });
+  try {
+    gitInit(dir, { commit: true });
+    const r = run(dir, "--routes", "--json");
+    assert.equal(r.status, 1);
+    const j = JSON.parse(r.stdout);
+    assert.deepEqual(j.routes, []);
+    assert.match(j.reason, /App Router/);
+  } finally { cleanup(dir); }
+});


### PR DESCRIPTION
Found by benchmarking `--callers` against a competing tool and then diffing agentmap's own two code paths against each other across 18 adversarial fixtures.

## Correctness

| Bug | Age | Effect |
|---|---|---|
| `SyntaxKind.JsxMemberExpression` does not exist in TypeScript (it is a Babel/ESTree node type) — the enum read returned `undefined`, so `getParentIfKind(undefined)` never matched | since 0.17.0 | the entire `<Foo.Bar />` branch was dead code |
| Enclosing-scope lookup stopped at the first function ancestor | pre-existing | `{items.map(x => <Row/>)}` reported `<module>` — 17 of 65 real call sites across two repos |
| `invocationOf()` matched only `CallExpression`, never `NewExpression` | pre-existing | **a class reachable only via `new` reported zero callers** — silently, exit 1, indistinguishable from unused. Also broke `--depth >= 2` |
| Sidecar keyed edges on the declaration's own name | new in this PR, fixed here | `export { impl as Widget }` answered 0 cached vs 1 live |
| Sidecar emitted every `getDefinitionNodes()` target | new in this PR, fixed here | `const wrapped = helper; wrapped()` credited `helper` with a call it never names |

## Performance

`--callers` was ~1500ms. Profiling put ~750–860ms — about half — in the **first** touch of the type-checker (`getExportedDeclarations()` forcing a full-program bind), a cost that is nearly fixed: a 2-reference symbol pays the same as a 119-reference one, and scoping the Project to a file's known dependents (251 files → 50) cut it only ~24%, because the bulk is binding `lib.d.ts` and `@types`.

Two cheaper routes were measured and rejected: dropping the redundant `scripts/**` glob (no effect — the cost was first-add overhead, not that glob) and prefiltering resolve candidates by names declared-or-imported in the file (**drops 35–44% of real edges**, because React code overwhelmingly calls names bound at nested scope).

So the checker work moves off the query path entirely. `--build-edges` sweeps every file once and writes `.claude/agentmap/calledges.json`; `--callers` reads it.

**1514ms → 78ms.**

It is a cache, never a second source of truth. The key binds it to the exact map it came from (HEAD / dirty fingerprint / schema / edge format), so stale, corrupt, `--depth >= 2` and `--calls` all fall back to the live walk. No configuration serves a stale answer. Building costs ~4x a map rebuild, so it is explicit — the post-commit hook runs it detached, lock-guarded and timeout-capped; `AGENTMAP_HOOK_EDGES=0` opts out. `--relates` / `--find` / `--hubs` / `--map` neither read nor write it and are unchanged.

## Verification

- **454/454 tests pass** (13 new)
- 12/12 symbols in one real repo and 25/25 in another: cached output **byte-identical** to the live walk
- 13/13 adversarial fixtures agree

## Known limitation

A barrel that both `export * from "./a"` and locally redefines the name is the one shape where the two paths still disagree — and the cache is the correct one. ES semantics say the local binding shadows the star-export, so `a.ts`'s copy is unreachable; the sweep agrees (0) while `findReferencesAsNodes()` over-reports (1). Documented rather than bug-compatibly reproduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)