### PR TITLE
feat: --affected (covering tests) and --kind (filter by declaration kind)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,26 @@
 All notable changes to agentmap are documented here.
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Added
+- **`--affected <path>`: which tests cover this file.** Walks the transitive
+  reverse-dependency closure and keeps the test files, reporting hop distance so a
+  long list stays triageable. The more valuable answer is the empty one — before a
+  risky edit, "nothing covers this" is exactly what you want to know, so it is
+  stated in words rather than printed as an empty list that reads like a failed
+  lookup. A bare filename resolves when unambiguous and refuses to guess when not.
+
+  Test detection is deliberately narrow: `__tests__`/`tests?` as a bare path
+  SEGMENT and a `.test.`/`.spec.` infix — a substring check would count
+  `src/latest/helper.ts`, which a test pins.
+
+- **`--kind <k>` on `--find` / `--search`.** Filters by declaration kind, matched
+  loosely and case-insensitively, so `--kind function` finds `FunctionDeclaration`
+  and `--kind type` finds `TypeAliasDeclaration` — nobody should need ts-morph's
+  enum spelling to narrow a search. The active filter is echoed back so an empty
+  result is explicable rather than mysterious.
+
 ## [0.19.0] - 2026-07-26
 
 ### Fixed

--- a/agentmap.mjs
+++ b/agentmap.mjs
@@ -2836,7 +2836,10 @@ Usage: agentmap [command] [--json]
 
 Query commands:
   --any <q>            route a query: file → symbol → feature → live git-grep
-  --find <sym>         find symbols by (sub)name (exports + non-exported top-level)
+  --find <sym> [--kind <k>]
+                       find symbols by (sub)name (exports + non-exported top-level)
+                       --kind filters by declaration kind, matched loosely:
+                       function / interface / type / class / variable
   --search <q>         rank symbols by BM25 lexical relevance (vague NL queries)
   --relates <path>     a file's exports/imports/dependents + related files
   --callers <sym> [--in <path>] [--depth N]
@@ -2855,6 +2858,8 @@ Query commands:
                        layout chain, and re-export shim aliases
   --route <url|file>   what serves this URL (or which URL a file serves):
                        matched file, methods, layout chain, RSC boundary
+  --affected <path>    test files that transitively import this file — what to
+                       re-run after changing it (and what has NO cover at all)
   --hubs               top files by PageRank importance
   --print              dump the full cached map as JSON
   --export <mermaid|dot> [--focus <p>]
@@ -2906,6 +2911,12 @@ async function main() {
   // codes are identical in both modes.
   const wantJson = has("--json");
   const out = (obj, prose) => { if (wantJson) console.log(JSON.stringify(obj)); else prose(); };
+  // --kind: filter symbol results by declaration kind. Matched LOOSELY and
+  // case-insensitively against the ts-morph kind name, so `--kind function`
+  // finds FunctionDeclaration and `--kind type` finds TypeAliasDeclaration —
+  // nobody should have to know ts-morph's enum spelling to narrow a search.
+  const kindFilter = arg("--kind");
+  const kindOk = (k) => !kindFilter || String(k || "").toLowerCase().includes(kindFilter.toLowerCase());
 
   // --include-dts is a GLOBAL modifier (like --json), valid with any query
   // command or none: it flips the module-scoped INCLUDE_DTS so extractFacts keeps
@@ -2926,14 +2937,14 @@ async function main() {
     "--help", "-h", "--version", "-v", "--install-hooks", "--hook-status", "--doctor", "--install-skill", "--platform", "--project", "--global",
     "--dry-run", "--setup-mcp", "--mcp", "--build-edges",
     "--any", "--find", "--search", "--relates", "--callers", "--calls", "--in", "--depth", "--map", "--export", "--focus", "--tokens",
-    "--symbols", "--feature", "--features", "--hubs", "--routes", "--route",
+    "--symbols", "--feature", "--features", "--hubs", "--routes", "--route", "--affected", "--kind",
   ]);
 
   // A token consumed as the VALUE of a value-taking flag is never itself a flag —
   // so a dash-leading query like `--any "-O/bin/sh"` is bound as the query, not
   // mistaken for an unknown flag. (arg() already rejects a "--"-leading value, so
   // `--any --foo` still falls through to the missing-arg guard instead.)
-  const VALUE_FLAGS = new Set(["--any", "--find", "--search", "--relates", "--callers", "--calls", "--in", "--depth", "--export", "--feature", "--focus", "--tokens", "--symbols", "--platform", "--route"]);
+  const VALUE_FLAGS = new Set(["--any", "--find", "--search", "--relates", "--callers", "--calls", "--in", "--depth", "--export", "--feature", "--focus", "--tokens", "--symbols", "--platform", "--route", "--affected", "--kind"]);
   const valueIdx = new Set();
   for (let i = 0; i < args.length - 1; i++) if (VALUE_FLAGS.has(args[i])) valueIdx.add(i + 1);
 
@@ -2968,9 +2979,10 @@ async function main() {
     "--mcp": [], "--install-hooks": ["--dry-run"],
     "--install-skill": ["--platform", "--project", "--global", "--dry-run"],
     "--hook-status": [], "--doctor": [], "--setup-mcp": ["--dry-run"], "--build-edges": [],
-    "--any": [], "--find": [], "--search": [], "--relates": [], "--callers": ["--in", "--depth"], "--calls": ["--in", "--depth"], "--map": ["--focus", "--tokens"], "--export": ["--focus"],
+    "--any": [], "--relates": [], "--callers": ["--in", "--depth"], "--calls": ["--in", "--depth"], "--map": ["--focus", "--tokens"], "--export": ["--focus"],
     "--symbols": [], "--feature": [], "--features": [], "--hubs": [], "--print": [],
-    "--routes": [], "--route": [],
+    "--find": ["--kind"], "--search": ["--kind"],
+    "--routes": [], "--route": [], "--affected": [],
   };
   const presentCommands = Object.keys(COMMANDS).filter(has);
   if (presentCommands.length > 1) {
@@ -3148,10 +3160,11 @@ async function main() {
     else {
       const data = ensureFresh();
       const lex = bm25Search(data.lexical, data.files, raw);
+      if (kindFilter) { lex.matches = lex.matches.filter((m) => kindOk(m.kind)); lex.total = lex.matches.length; }
       if (!lex.matches.length) process.exitCode = 1;
       const trunc = lex.total > lex.matches.length;
-      out({ command: "search", query: raw, total: lex.total, shown: lex.matches.length, truncated: trunc, matches: lex.matches }, () => {
-        console.log(`search "${raw}": ${lex.total} match${trunc ? ` (showing top ${lex.matches.length} by relevance)` : ""}`);
+      out({ command: "search", query: raw, ...(kindFilter ? { kind: kindFilter } : {}), total: lex.total, shown: lex.matches.length, truncated: trunc, matches: lex.matches }, () => {
+        console.log(`search "${raw}"${kindFilter ? ` kind~${kindFilter}` : ""}: ${lex.total} match${trunc ? ` (showing top ${lex.matches.length} by relevance)` : ""}`);
         if (lex.matches.length) console.log(lex.matches.map((m) => `  ${m.file} → ${m.name} (${m.kind})  [${m.score}]`).join("\n"));
       });
     }
@@ -3164,16 +3177,16 @@ async function main() {
       const all = [];
       for (const [path, f] of Object.entries(data.files)) {
         for (const e of f.exports)
-          if (e.name.toLowerCase().includes(q)) all.push(symMatch(path, e));
+          if (e.name.toLowerCase().includes(q) && kindOk(e.kind)) all.push(symMatch(path, e));
         if (INCLUDE_LOCALS) for (const e of (f.locals || []))
-          if (e.name.toLowerCase().includes(q)) all.push({ file: path, name: e.name, kind: e.kind, local: true });
+          if (e.name.toLowerCase().includes(q) && kindOk(e.kind)) all.push({ file: path, name: e.name, kind: e.kind, local: true });
       }
       if (!all.length) process.exitCode = 1;
       const ranked = rankMatches(data.files, all);
       const matches = ranked.slice(0, SYMBOL_MATCH_LIMIT);
       const truncated = ranked.length > matches.length;
-      out({ command: "find", query: raw, total: ranked.length, shown: matches.length, truncated, matches }, () => {
-        console.log(`find "${raw}": ${ranked.length} match${truncated ? ` (showing top ${matches.length} by pagerank — narrow your query)` : ""}`);
+      out({ command: "find", query: raw, ...(kindFilter ? { kind: kindFilter } : {}), total: ranked.length, shown: matches.length, truncated, matches }, () => {
+        console.log(`find "${raw}"${kindFilter ? ` kind~${kindFilter}` : ""}: ${ranked.length} match${truncated ? ` (showing top ${matches.length} by pagerank — narrow your query)` : ""}`);
         if (matches.length) console.log(matches.map((m) => `  ${m.file} → ${m.name} (${m.kind})${originNote(m)}`).join("\n"));
       });
     }
@@ -3405,6 +3418,45 @@ async function main() {
       console.log(`features (${list.length}):`);
       for (const [k, n] of list) console.log(`  ${k} (${n} files)`);
     });
+  } else if (has("--affected")) {
+    const raw = arg("--affected");
+    if (!raw) { console.error("--affected needs a file path, e.g. `--affected lib/auth.ts`"); process.exitCode = 2; }
+    else {
+      const data = ensureFresh();
+      // Accept a suffix so `--affected auth.ts` works without the full path, but
+      // refuse to guess when it is ambiguous — silently picking one of two files
+      // would answer a question the user did not ask.
+      const exact = data.files[raw] ? [raw] : Object.keys(data.files).filter((p) => p === raw || p.endsWith(`/${raw}`));
+      if (!exact.length) {
+        out({ command: "affected", query: raw, error: "no match", candidates: [], _code: 1 },
+          () => console.log(`affected "${raw}": no such file in the map`));
+        process.exitCode = 1;
+      } else if (exact.length > 1) {
+        out({ command: "affected", query: raw, error: "ambiguous", candidates: exact, _code: 1 }, () => {
+          console.log(`affected: "${raw}" matches ${exact.length} files — name one:`);
+          for (const c of exact) console.log(`  ${c}`);
+        });
+        process.exitCode = 1;
+      } else {
+        const file = exact[0];
+        const reach = transitiveDependents(data, file);
+        const tests = [...reach].filter(([p]) => TEST_FILE_RE.test(p))
+          .sort((a, b) => a[1] - b[1] || (a[0] < b[0] ? -1 : 1))
+          .map(([p, hop]) => ({ file: p, hop }));
+        const selfIsTest = TEST_FILE_RE.test(file);
+        out({
+          command: "affected", query: raw, file,
+          dependents: reach.size, tests: tests.length, covered: tests.length > 0 || selfIsTest,
+          affected: tests,
+        }, () => {
+          console.log(`affected by ${file}: ${tests.length} test file${tests.length === 1 ? "" : "s"} (of ${reach.size} transitive dependents)`);
+          for (const t of tests) console.log(`  ${t.file}  [${t.hop} hop${t.hop === 1 ? "" : "s"}]`);
+          // An empty list is the ANSWER, not a failure — and it is the answer that
+          // matters most before a risky edit, so say it in words.
+          if (!tests.length && !selfIsTest) console.log("  (none — this file has no test coverage reachable through imports)");
+        });
+      }
+    }
   } else if (has("--routes")) {
     const data = ensureFresh();
     const routes = buildRouteTable(data);
@@ -3564,6 +3616,35 @@ function invocationOf(id, SyntaxKind) {
     if (el && el.getTagNameNode() === tagHolder) return el;
   }
   return null;
+}
+
+// A test file, by the conventions every JS test runner actually uses. Kept
+// deliberately narrow: `/test/` as a bare path segment (not a substring, or
+// `src/latest/x.ts` matches), and a `.test.`/`.spec.` infix before the extension.
+const TEST_FILE_RE = /(^|\/)(__tests__|__mocks__|tests?)\/|\.(test|spec)\.[cm]?[jt]sx?$/;
+
+// Transitive reverse dependency closure — every file that reaches `start` through
+// import edges, at any depth. BFS with a visited set: an import cycle is normal in
+// real code (barrels, type-only round-trips) and must terminate, not recurse.
+// Returns a Map of file -> hop distance so a caller can report how far away a
+// dependent is, which is what makes a long list triageable.
+function transitiveDependents(data, start) {
+  const seen = new Map();
+  let frontier = [start];
+  let hop = 0;
+  while (frontier.length) {
+    hop++;
+    const next = [];
+    for (const f of frontier) {
+      for (const d of data.files[f]?.dependents || []) {
+        if (seen.has(d) || d === start) continue;
+        seen.set(d, hop);
+        next.push(d);
+      }
+    }
+    frontier = next;
+  }
+  return seen;
 }
 
 // ---------------------------------------------------------------------------

--- a/test/affected-kind.test.mjs
+++ b/test/affected-kind.test.mjs
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: MIT
+// ============================================================================
+//  --affected (source -> covering tests) and --kind (filter by declaration kind).
+//
+//  --affected answers "what do I re-run after changing this", and — more useful
+//  before a risky edit — "does anything cover this at all". An empty list is the
+//  ANSWER, not a failure, so it must be stated plainly rather than looking like
+//  a lookup that went wrong.
+//
+//  Run: node --test test/affected-kind.test.mjs
+// ============================================================================
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { makeRepo, gitInit, run, cleanup } from "./helpers.mjs";
+
+// core <- mid <- feature.test  (2 hops), core <- direct.test (1 hop),
+// and `orphan.ts` which nothing tests at all.
+function repo() {
+  return {
+    "src/core.ts": "export function core(){ return 1; }\n",
+    "src/mid.ts": 'import { core } from "./core";\nexport function mid(){ return core() + 1; }\n',
+    "src/orphan.ts": "export function orphan(){ return 0; }\n",
+    "test/direct.test.mjs": 'import { core } from "../src/core.ts";\ncore();\n',
+    "test/feature.test.mjs": 'import { mid } from "../src/mid.ts";\nmid();\n',
+    // Named to look testish without being a test: `latest` contains "test" as a
+    // substring, and a bare-substring check would wrongly count it.
+    "src/latest/helper.ts": "export function helper(){ return 2; }\n",
+  };
+}
+
+const json = (dir, ...a) => JSON.parse(run(dir, ...a, "--json").stdout);
+
+test("--affected reports covering tests with their hop distance", () => {
+  const dir = makeRepo(repo());
+  try {
+    gitInit(dir, { commit: true });
+    const j = json(dir, "--affected", "src/core.ts");
+    const byFile = Object.fromEntries(j.affected.map((a) => [a.file, a.hop]));
+    assert.equal(byFile["test/direct.test.mjs"], 1, "direct importer is 1 hop");
+    assert.equal(byFile["test/feature.test.mjs"], 2, "reached through mid.ts is 2 hops");
+    assert.equal(j.tests, 2);
+    assert.equal(j.covered, true);
+  } finally { cleanup(dir); }
+});
+
+test("an uncovered file says so — the empty list is the answer", () => {
+  const dir = makeRepo(repo());
+  try {
+    gitInit(dir, { commit: true });
+    const r = run(dir, "--affected", "src/orphan.ts");
+    assert.equal(r.status, 0, "no coverage is a valid answer, not an error");
+    const j = JSON.parse(run(dir, "--affected", "src/orphan.ts", "--json").stdout);
+    assert.deepEqual(j.affected, []);
+    assert.equal(j.covered, false);
+    assert.match(r.stdout, /no test coverage/i, "must say it in words, not just print nothing");
+  } finally { cleanup(dir); }
+});
+
+test("a path segment merely CONTAINING 'test' is not a test file", () => {
+  const dir = makeRepo({
+    ...repo(),
+    // src/latest/helper.ts is imported by a real test, so it will appear in the
+    // dependents walk — but it must never be counted as a test file itself.
+    "test/uses-latest.test.mjs": 'import { helper } from "../src/latest/helper.ts";\nhelper();\n',
+  });
+  try {
+    gitInit(dir, { commit: true });
+    const j = json(dir, "--affected", "src/latest/helper.ts");
+    assert.ok(!j.affected.some((a) => a.file === "src/latest/helper.ts"), "the file itself is never its own test");
+    assert.deepEqual(j.affected.map((a) => a.file), ["test/uses-latest.test.mjs"]);
+  } finally { cleanup(dir); }
+});
+
+test("--affected accepts a bare filename but refuses to guess when ambiguous", () => {
+  const dir = makeRepo({
+    "src/a/thing.ts": "export const a = 1;\n",
+    "src/b/thing.ts": "export const b = 2;\n",
+    "src/only.ts": "export const c = 3;\n",
+  });
+  try {
+    gitInit(dir, { commit: true });
+    const uniq = run(dir, "--affected", "only.ts", "--json");
+    assert.equal(JSON.parse(uniq.stdout).file, "src/only.ts", "an unambiguous suffix resolves");
+    const amb = run(dir, "--affected", "thing.ts", "--json");
+    assert.equal(amb.status, 1);
+    const j = JSON.parse(amb.stdout);
+    assert.equal(j.error, "ambiguous");
+    assert.equal(j.candidates.length, 2, "picking one silently would answer a question nobody asked");
+  } finally { cleanup(dir); }
+});
+
+test("--affected on an unknown path exits 1", () => {
+  const dir = makeRepo(repo());
+  try {
+    gitInit(dir, { commit: true });
+    const r = run(dir, "--affected", "src/nope.ts", "--json");
+    assert.equal(r.status, 1);
+    assert.equal(JSON.parse(r.stdout).error, "no match");
+  } finally { cleanup(dir); }
+});
+
+test("--kind narrows --find loosely, without ts-morph enum spelling", () => {
+  const dir = makeRepo({
+    "src/mix.ts":
+      "export function doThing(){ return 1; }\n" +
+      "export type ThingShape = { a: number };\n" +
+      "export const thingConst = 3;\n" +
+      "export interface ThingIface { b: string }\n",
+  });
+  try {
+    gitInit(dir, { commit: true });
+    const all = json(dir, "--find", "thing");
+    assert.equal(all.total, 4);
+    // `function` must match FunctionDeclaration, `type` TypeAliasDeclaration, etc.
+    assert.deepEqual(json(dir, "--find", "thing", "--kind", "function").matches.map((m) => m.name), ["doThing"]);
+    assert.deepEqual(json(dir, "--find", "thing", "--kind", "type").matches.map((m) => m.name), ["ThingShape"]);
+    assert.deepEqual(json(dir, "--find", "thing", "--kind", "interface").matches.map((m) => m.name), ["ThingIface"]);
+    // Case-insensitive, and echoed back so an empty result is explicable.
+    assert.equal(json(dir, "--find", "thing", "--kind", "FUNCTION").total, 1);
+    assert.equal(json(dir, "--find", "thing", "--kind", "function").kind, "function");
+  } finally { cleanup(dir); }
+});
+
+test("a --kind that matches nothing is an honest empty result, exit 1", () => {
+  const dir = makeRepo({ "src/mix.ts": "export function doThing(){ return 1; }\n" });
+  try {
+    gitInit(dir, { commit: true });
+    const r = run(dir, "--find", "thing", "--kind", "enum", "--json");
+    assert.equal(r.status, 1);
+    assert.equal(JSON.parse(r.stdout).total, 0);
+  } finally { cleanup(dir); }
+});
+
+test("--kind is a modifier, not a command — orphaned it is a usage error", () => {
+  const dir = makeRepo({ "src/a.ts": "export const a = 1;\n" });
+  try {
+    gitInit(dir, { commit: true });
+    const r = run(dir, "--kind", "function");
+    assert.equal(r.status, 2, "--kind with no --find/--search must not silently build the map");
+  } finally { cleanup(dir); }
+});


### PR DESCRIPTION
Closes two gaps a competing tool had on agentmap.

## `--affected <path>`
Transitive reverse-dependency closure, filtered to test files, with hop distance.

The empty result is the point — before a risky edit, *"nothing covers this"* is the answer you most want, so it's stated in words rather than printed as an empty list that reads like a failed lookup.

Test detection is narrow on purpose: `__tests__`/`tests?` as a bare path **segment** plus a `.test.`/`.spec.` infix. A substring check would count `src/latest/helper.ts` — pinned by a test.

A bare filename resolves when unambiguous and refuses to guess when not; silently picking one of two files answers a question nobody asked.

## `--kind <k>`
Filters `--find`/`--search` by declaration kind, matched loosely and case-insensitively — `--kind function` finds `FunctionDeclaration`, `--kind type` finds `TypeAliasDeclaration`. Nobody should need ts-morph's enum spelling to narrow a search. It's a modifier, not a command: orphaned, it's a usage error rather than a silent full build.

475/475 tests pass (8 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)