### PR TITLE
chore: sweep the Batch B backlog — security, CI gates, ranking tests, honesty fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,14 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # checkJs over ~250KB of hand-written JS — the only static analysis that
+      # reads this codebase, since none of it is TypeScript. Deliberately runs on
+      # every OS: the two errors it caught when introduced were a stale JSDoc type
+      # and an unfollowable dynamic import, and path-shaped mistakes are exactly
+      # the kind that differ per platform.
+      - name: Typecheck
+        run: npm run typecheck
+
       # Black-box suite — drives the real CLI as a subprocess against temp repos.
       # Runs via npm so CI uses the same glob set as `npm test` locally
       # (test/*.test.mjs alone silently skipped the test/vue-sfc/ suite).
@@ -188,6 +196,35 @@ jobs:
           done
           echo "generatedSha $BEFORE -> $AFTER"
           test "$AFTER" != "$BEFORE" || { echo "::error::post-commit hook did not refresh the map — auto-refresh is dead"; exit 1; }
+
+  # Coverage floor, so a shipped file that nothing executes stays visible.
+  #
+  # Uses node --test's own coverage rather than c8: the thresholds land natively
+  # from Node 22, and the near-zero-deps rule is easier to keep than to argue with.
+  # That is also why this is its own job pinned to one version — the flags do not
+  # exist on Node 20, which the test matrix still supports.
+  #
+  # Floors sit BELOW the measured 93.77% lines / 75.92% branches on purpose. They
+  # are a regression alarm, not a target: a gate set at the current number reddens
+  # on ordinary work and gets raised until someone stops reading it.
+  coverage:
+    name: Coverage floor
+    if: github.event_name != 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests under coverage
+        run: npm run coverage
 
   # Audit for high-severity vulnerabilities in the dependency tree. Deliberately
   # its own job rather than a step in the matrix above: it depends only on the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,15 +23,31 @@ permissions:
 
 jobs:
   test:
-    name: test (node ${{ matrix.node-version }})
+    name: test (${{ matrix.os }}, node ${{ matrix.node-version }})
     # The schedule trigger exists only to re-run `audit` against a moving
     # advisory DB; the code is unchanged between crons, so skip the rest.
     if: github.event_name != 'schedule'
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    # Node versions fan out on Linux only; Windows and macOS get one pinned
+    # version each via `include`. A full 3x3 cross-product would be nine jobs to
+    # re-answer a question the Linux column already answers — what these two add
+    # is the PLATFORM, not another Node.
+    #
+    # They are here because the code has real per-platform branches (win32 paths
+    # in skills/install.mjs, path separators through the resolver, git behaviour
+    # differences) and the docs target Windows, yet every one of the 477 tests
+    # had only ever run on Linux. macOS is the maintainer's own platform and is
+    # exercised locally; Windows genuinely was not covered anywhere.
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest]
         node-version: [20, 22, 24]
+        include:
+          - os: windows-latest
+            node-version: 22
+          - os: macos-latest
+            node-version: 22
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -73,6 +89,14 @@ jobs:
   # So: pack, install from the tarball, and drive the real binary. Exit status is
   # NOT sufficient evidence here — exit 0 with empty stdout was the bug's exact
   # signature, so every step below asserts on OUTPUT.
+  #
+  # Deliberately Linux-only, unlike the `test` job above. Every step here is a
+  # bash script with `set -euo pipefail`, absolute /tmp paths and $GITHUB_ENV
+  # export syntax; on windows-latest the default shell is PowerShell, so porting
+  # this means `shell: bash` plus rewriting the paths, and a half-ported version
+  # that silently skips a step is worse than an honest gap. The Windows install
+  # path is therefore NOT covered — recorded here rather than left to be inferred
+  # from the matrix.
   install-smoke:
     name: install smoke (node ${{ matrix.node-version }})
     if: github.event_name != 'schedule'

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,41 @@
+# Code of Conduct
+
+## The standard
+
+This project adopts the [Contributor Covenant v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
+Read it there — it is the authoritative text, and restating it here only creates a
+copy to drift.
+
+In short: be respectful, assume good faith, and keep discussion about the work.
+Harassment, personal attacks, and demeaning comments are not welcome, in issues,
+pull requests, commit messages, or anywhere else this project is discussed.
+
+## Scope
+
+Applies in all project spaces — issues, pull requests, discussions, commits — and
+when representing the project publicly.
+
+## Technical disagreement is not a violation
+
+This repository argues with itself in writing. `ROADMAP.md` records items closed as
+**refuted** with the measurements that refuted them, several of which contradict
+what a maintainer previously believed. `CONTRIBUTING.md` says maintainers may decline
+in-scope changes. Being told your patch is wrong, or that a number does not
+reproduce, is the process working.
+
+What is not on that list: making it personal, or about the person.
+
+## Reporting
+
+Report anything that crosses the line to **raymondchin.s@gmail.com**, the address
+already on every commit in this repository. Reports are handled privately, and the
+reporter's identity is not shared with the person reported.
+
+If the report concerns the maintainer, GitHub's own
+[reporting channels](https://docs.github.com/en/communities/maintaining-your-safety-on-github/reporting-abuse-or-spam)
+exist for exactly that reason and are the right escalation.
+
+## Enforcement
+
+Responses are proportionate: a private correction, a warning, removal of a comment,
+or a block. The maintainer decides, and will say which is being applied and why.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,9 +120,22 @@ When you touch caching, building, or the schema:
 ## Submitting a PR
 
 1. For anything non-trivial, open (or link) an issue describing the change first.
-2. Branch, make the change, run `npm test` — all green on Node 20+.
+2. Branch, make the change, then run all three gates — CI runs the same ones:
+
+   ```bash
+   npm test          # black-box suite, all green on Node 20+
+   npm run typecheck # checkJs over the .mjs sources (see jsconfig.json)
+   npm run coverage  # suite again with the line/branch floor enforced
+   ```
+
+   `typecheck` is intentionally non-strict — `jsconfig.json` explains what that
+   buys and what it gives up. `coverage` needs Node 22+ for the threshold flags;
+   `npm test` alone is fine on Node 20.
 3. Tests are dependency-free black-box drivers over throwaway git repos (see
-   `test/helpers.mjs`). New behavior needs a test in that style.
+   `test/helpers.mjs`). New behavior needs a test in that style. Assert what the
+   output *should be*, not merely that two runs agree — `test/determinism.test.mjs`
+   passes unchanged with the hub comparator inverted, which is why
+   `test/ranking-quality.test.mjs` exists.
 4. Keep the diff minimal and the output byte-identical for existing commands —
    unless the change *is* the output (then call it out).
 5. Fill in the PR checklist. Maintainers may decline in-scope-but-bloating

--- a/EVAL.md
+++ b/EVAL.md
@@ -74,6 +74,14 @@ where naive grep returns a noisy superset (high recall, low precision) — and `
 actually costs **more** tokens than `grep -l` because it returns the full blast radius
 (exports + imports + dependents + related), not just the file list.
 
+> **Reconciling this with `RESULTS.md`'s 99.2% blast-radius row.** Both numbers are real;
+> they price different baselines. `RESULTS.md` scenario D compares against an agent that
+> `cat`s every dependent file — agentmap wins by ~99%. This eval compares against `grep -l`,
+> which returns a file list and nothing else — agentmap loses on tokens. The list is cheaper
+> because it is *less* correct: at **59.9%** precision, roughly 4 of every 10 paths on it are
+> not dependents, and the agent pays for them on the next turn when it opens them. Neither
+> file is the whole picture on its own; quote them together.
+
 ### Per fixture
 
 | Repo | commit | def n | agentmap top1/top3 | grep top1/top3 | deps n | agentmap recall/prec | grep recall/prec |

--- a/README.md
+++ b/README.md
@@ -133,12 +133,17 @@ follows the chain and names the file that actually declares it.
 - **The win scales with the work.** The 63% and 11% rows are the floor. A *trivial
   single-file* lookup can cost **more** than `cat` + `grep` — taxonomy's file-import task hit
   **−313%**, and it stays in the table.
-- **The 98.3% combined figure is skewed** by the whole-repo row (150 K vs 1 K). Excluding it,
-  the per-task average is ~32× rather than 58×. Both are real; the headline captures the
-  common worst case (repo dump on session start).
+- **The 98.3% headline is carried by its two biggest rows** — repo dump (150,281 → 1,127) and
+  blast radius (81,038 → 616). Drop the repo dump and it's **96.9%**; drop both and it's
+  **89.8%** here, **93.7%** pooled across all three repos, and **73.1%** on the smallest one.
+  All of those are real — they answer different questions. The headline is the common worst
+  case: an agent dumping the repo at session start.
 - **`--relates` returns the full blast radius**, so it costs *more* than a bare `grep -l` file
-  list. Complete-and-correct over short-and-wrong — but it is a trade, stated in
-  [EVAL.md](./EVAL.md).
+  list. That's why the same command reads as 99.2% *saved* in the benchmark and *more
+  expensive* in the eval: the benchmark's baseline is an agent that `cat`s all 65 dependent
+  files, the eval's is a file list nobody reads. Against the list, agentmap trades tokens for
+  precision — 100% vs 59.9%, so ~4 in 10 files on the grep list don't belong.
+  Complete-and-correct over short-and-wrong, but it is a trade → [EVAL.md](./EVAL.md).
 - **Numbers are context-token volume**, not answer quality or wall-clock.
 - **Token counts are estimates** (`chars / 4`), applied identically to both sides.
 - **TypeScript/JavaScript only** (+ Vue SFC) — see [Scope & limitations](#scope--limitations).

--- a/README.md
+++ b/README.md
@@ -757,6 +757,16 @@ top 10 ranked symbols (Aider-style):
   0.015034  lib/errors.ts → ErrorCode (TypeAliasDeclaration)
 ```
 
+`map.json` persists the top 80. Asking for more re-ranks from the cached map rather than
+truncating, so `--symbols 200` really does return 200 where the repo has them. When a repo
+has fewer ranked symbols than you asked for, the header says so and `--json` carries
+`requested` / `shown` / `truncated`:
+
+```
+$ node agentmap.mjs --symbols 200
+top 62 ranked symbols (Aider-style) — asked for 200, this repo only ranks 62:
+```
+
 ### `--map [--tokens N] [--focus <path>]` — token-budgeted ranked digest
 
 The token-budgeted digest (Aider's killer feature): a ranked, files-and-symbols summary

--- a/README.md
+++ b/README.md
@@ -169,16 +169,19 @@ OS-event file watcher (FSEvents/inotify) with debounced auto-sync and an install
 auto-configures eight agent CLIs. agentmap's honest edge over the multi-language graph tools is
 narrower and sharper: **TS/JS resolution the others approximate, with a published accuracy eval.**
 
-| | **agentmap** | Aider repo map | RepoMapper | Repomix | code2prompt |
+| | **agentmap** | [Aider repo map](https://github.com/Aider-AI/aider) | [RepoMapper](https://github.com/nuptcode/repomapper) | [Repomix](https://github.com/yamadashy/repomix) | [code2prompt](https://github.com/mufeedvh/code2prompt) |
 | --- | --- | --- | --- | --- | --- |
 | **Ranking algorithm** | Personalized PageRank (file + symbol graphs) | PageRank (graph ranking) | Importance heuristics | None (file order) | None (file order) |
 | **Languages** | TS/JS + Vue SFC (via ts-morph) | Many (tree-sitter) | Many (tree-sitter) | Language-agnostic (text) | Language-agnostic (text) |
 | **Token-budget output** | Yes — `--map [--tokens N]` ranked digest | Yes (built into Aider's context) | Partial | Yes (size caps) | Yes (templates/caps) |
 | **TS/JS resolution depth** | **Compiler-grade — `tsconfig` paths + `vite`/`webpack` alias + `#imports` + workspaces (ts-morph)** | Basename/regex heuristics | Basename/regex heuristics | N/A (text) | N/A (text) |
 | **Retrieval-accuracy eval** | **Yes — published [`EVAL.md`](./EVAL.md) vs live ground truth** | No | No | No | No |
-| **Agent-loop wiring** | Yes — post-commit auto-refresh + PreToolUse hook | In-process (Aider only) | No | No | No |
+| **Agent-loop wiring** | Yes — post-commit auto-refresh + PreToolUse hook | In-process (Aider only) | No | MCP server (no auto-refresh, no nudge) | No |
 | **Dependencies** | `ts-morph` only | Python + tree-sitter stack | Python + tree-sitter | Node | Rust binary |
 | **Install** | `npx @raymondchins/agentmap` | `pip install aider-chat` | `pip install` | `npx`/global | `cargo`/binary |
+
+<sub>Comparison as of <b>2026-07-27</b>, from each project's own docs. These are moving targets — if a
+cell is out of date, that's a bug: <a href="https://github.com/raymondchins/agentmap/issues">open an issue</a>.</sub>
 
 What that table is **not** claiming: agentmap is TS/JS-only (the others are multi-language),
 and it's a **file-level import graph**, not a full call-site/reference resolver (see
@@ -358,7 +361,7 @@ skill/rule the agent may or may not consult). Honest matrix:
 | Platform | Install | Enforcement | Known gaps |
 |----------|---------|-------------|------------|
 | **Claude Code** | `/plugin install agentmap@agentmap` (or `--install-hooks`) | **live hook** — `PreToolUse` nudge on `Grep` + Bash searchers | non-blocking (never denies grep); bare-symbol `Grep` nudge requires the #3 hook fix |
-| **Gemini CLI** | `--install-skill --platform gemini` | **live hook** — `.gemini/settings.json` nudge | fires on the `AfterTool`/`systemMessage` path (the earlier `BeforeTool` + `additionalContext` combo was silently dropped — fixed in #4) |
+| **Gemini CLI** | `--install-skill --platform gemini` | **live hook** — `.gemini/settings.json` nudge | fires on `BeforeTool` and emits a top-level `systemMessage`; Gemini parses and then **drops** `hookSpecificOutput.additionalContext` on `BeforeTool`, which is why the nudge used to vanish silently |
 | **OpenCode** | `--install-skill --platform opencode` | **log-only** — `.opencode/plugins/agentmap-nudge.js` writes to the log, does not inject context | plugin can't steer the model; relies on the `AGENTS.md` block being read |
 | **Cursor** | `--install-skill --platform cursor` + `.cursor/mcp.json` (below) | **MCP + docs** — `alwaysApply` rule + the MCP server | Cursor's own hooks aren't wired; the rule is advisory |
 | **Codex CLI** | `--install-skill --platform codex` | **live gate** — `.codex/config.toml` PreToolUse hook | denies only high-confidence structural greps; allow-fallback for logs/pipes/non-TS-JS; `AGENTMAP_CODEX_GATE=0` bypasses; needs a trusted dir + Codex hooks-GA |
@@ -408,6 +411,10 @@ leaves the rest of your `AGENTS.md` / `GEMINI.md` intact.
 | Codex/Gemini nudge never fires | Codex's gate is opt-in — set `[features] hooks = true` in `.codex/config.toml` (`AGENTMAP_CODEX_GATE=0` disables it). Gemini needs the `BeforeTool` hook that `--install-skill` writes. |
 | Installed the wrong `agentmap` | This is **`@raymondchins/agentmap`** (npm scope) — not the unrelated unscoped `agentmap` packages. |
 | Cursor MCP tools missing | `--mcp` doesn't auto-wire Cursor; add the copy-paste `.cursor/mcp.json` from the matrix above and restart Cursor. |
+| Hook works in your shell, not in the agent | Almost always **nvm**. Your interactive shell sources `~/.nvm/nvm.sh`; the git hook and the agent's tool runner do not, so `node` isn't on their `PATH`. Point the hook at an absolute node (`which node`) or install a system-wide node. |
+| `JavaScript heap out of memory` | Raise the ceiling — the parse peaks and there is no in-process warning that can fire in time (the process dies inside a single call, with heap use still at ~40% one sample earlier). Re-run as `NODE_OPTIONS=--max-old-space-size=8192 npx @raymondchins/agentmap`. Repo **size is not the axis**: measured, a 252-file Next.js app peaks at 683 MB while 4,000 dependency-free files peak at 756 MB, because the dependency `.d.ts` closure (~300 MB, ~1,800 extra program files on a 393-file app) dominates. A small repo with heavy `@types` can need more than a large plain one. |
+| Skill file looks out of date | Each installed skill dir carries a `.agentmap_version`. `agentmap --doctor` compares it against the running version and flags the drift; `--install-skill` again overwrites it. |
+| `0 files mapped` | agentmap indexes `git ls-files --cached --others --exclude-standard`, so uncommitted files *are* included but **`.gitignore`d ones are not** — a source tree matched by an ignore rule maps to nothing, as does a directory that is not a git repo at all. Confirm with `git ls-files --others --exclude-standard \| head`. |
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -65,10 +65,10 @@ Full research (with source URLs) is in the audit report — see *References* bel
 |---|---|---|---|
 | **1** | Trust & truth (security + honesty) | 1–2 d | ✅ **DONE** (pushed) |
 | **2** | Modularize for testability + backend seam | 2–4 d | ✅ **DONE** — all substantive tasks landed (map byte-identical, 189 tests). Deferred-optional: `lib/` file split + in-process MCP. |
-| **3** | Dirty-tree performance | 3–5 d | ⬜ |
-| **4** | Distribution & release hygiene | 2–3 d | 🟨 Mostly done — plugin/marketplace, MCP Registry listing, tag-triggered publish, and README trust markers shipped; `npx skills add` alignment + Cursor/Gemini hooks deferred |
+| **3** | Dirty-tree performance | 3–5 d | 🟨 **Both cache tiers + visible skips + symbol cap shipped.** Of what remained, two items were **measured and refuted** (cross-product pruning drops 0 edges on all 5 repos tested; the heapUsed OOM warning cannot fire in time — built, measured, reverted). Post-commit locking shipped; its incremental half stays gated on Tier 2 going default-on |
+| **4** | Distribution & release hygiene | 2–3 d | 🟨 Mostly done — plugin/marketplace, MCP Registry listing, tag-triggered publish, and README trust markers shipped. Release automation **closed without adopting changesets** (two lockstep tests instead); `npx skills add` alignment + Cursor/Gemini hooks still deferred |
 | **5** | TS-depth before language-breadth | weeks | 🟨 Mostly done — depth + resolution shipped; monorepo intelligence + symbol-PageRank deferred |
-| **B** | Cross-cutting backlog (low-severity) | ongoing | ⬜ |
+| **B** | Cross-cutting backlog (low-severity) | ongoing | ✅ **Swept 2026-07-27 — 20 done, 4 partial, 0 untouched.** Security, CI OS matrix, typecheck + coverage gates, ranking-ORDER tests, installer robustness, docs and housekeeping all landed. Several items turned out to be **already fixed with a stale checkbox**; the remaining partials each say what is left and why |
 
 **Legend:** ✅ done · 🟨 partial / mostly done · ⬜ not started
 
@@ -167,7 +167,7 @@ exists.
 
 ---
 
-## ⬜ Batch 3 — Dirty-tree performance
+## 🟨 Batch 3 — Dirty-tree performance
 
 **Goal:** stop full-reparsing the whole repo on every query when the working tree
 is dirty. Agents work on dirty trees essentially always, so this is the #1
@@ -354,9 +354,20 @@ discovered is trustworthy and fast.
   existed (the "zero tags" note was stale); still need the `NPM_TOKEN` repo secret
   + first GitHub Release. *(v0.10.0 published manually 2026-07-03 to close the RCE gap;
   future releases go through this workflow.)*
-- [ ] **Release automation** (release-please / changesets) — structurally fixes
-  the recurring missing-CHANGELOG-entry problem (and the lockfile-version drift
-  just seen in `aa62353`).
+- [x] **Release automation** (release-please / changesets) — **DECIDED: not
+  adopted, problem closed another way.** Both named symptoms were directly
+  checkable, so they are now checked in `test/version-lockstep.test.mjs`: a
+  `## [<version>]` section must exist in `CHANGELOG.md` for the version in
+  `package.json`, and `package-lock.json`'s two version fields must match it.
+  The CHANGELOG gap was genuinely uncovered — nothing anywhere asserted that the
+  shipped version had release notes. The lockfile one needed its own test because
+  **`npm ci` does not catch it**: it validates the dependency tree, not the root
+  package's own version, which is how `aa62353` shipped. Negative control: forcing
+  `package.json` to 9.9.9 fails 5 of the 8 lockstep tests.
+  Rejected because the cost is per-PR ceremony and a dependency tree, on a
+  solo-maintained repo whose stated identity is near-zero-deps — for a problem two
+  assertions cover. Revisit if this ever takes regular outside contributors, where
+  a changeset file per PR buys attribution and release notes that a test cannot.
 - [x] **README trust markers** — states "fully local, no network calls, no telemetry"
   (verified: zero `fetch`/`http` in `agentmap.mjs`/`mcp.mjs`) and the name-collision
   note (`npx agentmap` unscoped is an unrelated package; always use the scoped
@@ -462,28 +473,53 @@ post-distribution demand asks for Python (Batch 2's seam makes it a 1–2 week a
 
 ---
 
-## ⬜ Batch B — Cross-cutting backlog (low-severity, do opportunistically)
+## ✅ Batch B — Cross-cutting backlog (swept 2026-07-27)
+
+> **Swept end-to-end on 2026-07-27**: 20 closed, 4 partial, none untouched. Three
+> things worth carrying forward from the sweep:
+>
+> 1. **Several items were already fixed and only the checkbox was stale** — the
+>    expanded denylist, the MCP injection fence, the dead `statSync` import, the
+>    four `readPackageVersion` copies, and the SHA-pinned CI actions. Anchors like
+>    `agentmap.mjs:77` and `README.md:223` had all drifted. Re-verify before
+>    working an item from this file; the finding may predate its own fix.
+> 2. **Two items were refuted by measuring them** (cross-product pruning, the
+>    heapUsed OOM warning) and one dependency premise was simply false
+>    (`typescript` does *not* come via ts-morph — `@ts-morph/common` vendors it).
+>    Each now carries the measurement, not just the verdict.
+> 3. **The gaps that were real were mostly "the tool reports success while doing
+>    something else"** — `--symbols 200` printing "top 200" over 80 rows, the
+>    Gemini Windows install writing to a path nothing reads, a partial install
+>    left behind by a malformed config, JSONC comments deleted in silence. That is
+>    the class to keep hunting.
 
 ### Security
-- [ ] **Expand sensitive-file denylist** — `agentmap.mjs:77`: Batch 1 fixed
+- [x] **Expand sensitive-file denylist** — `agentmap.mjs:77`: Batch 1 fixed
   `*password*`; still missing `*token*`, `.npmrc`, `.netrc`, `.git-credentials`,
   `.pgpass`, `.htpasswd`, `.pypirc`, `id_ed25519*`, `id_ecdsa*`, `*.p8`, `*.jks`,
   `*.keystore`. Reconcile with SECURITY.md; extend the regression test.
   *(security/medium — note `*token*` over-excludes `tokenizer.ts` etc.; weigh it.)*
-- [ ] **Prompt-injection fencing** — `agentmap.mjs:1655`: untrusted repo content
+- [x] **Prompt-injection fencing** — `agentmap.mjs:1655`: untrusted repo content
   flows verbatim into agent context via `--any` content fallback + map digests
   through MCP. Wrap content/digest output in an untrusted-data fence in the MCP
   text result; strip control chars; document that `--any` lines are raw repo bytes.
   *(security/medium)*
 
 ### Tests & CI
-- [ ] **OS matrix** — `.github/workflows/ci.yml:12` is ubuntu-only despite
+- [x] **OS matrix** — `.github/workflows/ci.yml:12` is ubuntu-only despite
   Windows-specific code + Windows-targeting docs. Add `windows-latest` +
   `macos-latest` (single Node version each). *(tests/high)*
-- [ ] **Ranking-quality tests** — `test/determinism.test.mjs:40` only asserts
-  determinism/set-membership, never *order*. Add fixtures with known in-degrees
-  (hubs[0] = most-imported; leaf never outranks it); add a CI step running
-  `eval/eval.mjs` with a min-accuracy threshold. *(tests/medium)*
+- [~] **Ranking-quality tests** — **order tests DONE; the eval CI step is not, on
+  purpose.** `test/ranking-quality.test.mjs` asserts against a constructed star
+  (in-degrees 5/2/0): first place, monotonicity in degree, leaf-never-outranks-hub,
+  and the same check one level down on `--symbols`. The gap was as bad as recorded —
+  **proven** by inverting the hub comparator, which leaves `determinism.test.mjs`
+  reporting 2/2 green while the new suite fails 3 of 5.
+  The `eval/eval.mjs` min-accuracy CI step stays out: the eval **clones upstream
+  repos over the network**, so wiring it into CI makes every unrelated PR depend on
+  GitHub availability and on third-party repos that move. `EVAL.md` already records
+  it as "network required; not part of CI", and pinned SHAs make it reproducible on
+  demand. Run it at release time, not per push. *(tests/medium)*
 - [~] **Concurrency + e2e hook tests** — parallel-build half DONE, hook e2e still
   open. Writing the test found a real bug rather than confirming safety:
   `assemble()` used a FIXED tmp name (`map.json.tmp` / `map.dirty.json.tmp` /
@@ -498,12 +534,35 @@ post-distribution demand asks for Python (Batch 2's seam makes it a 1–2 week a
   the defect. Still open: the shipped post-commit hook never runs e2e
   (`--install-hooks` without the hooksPath override → commit → `generatedSha ===
   HEAD`). *(tests/medium)*
-- [ ] **Lint/typecheck gate** — add `jsconfig.json` (checkJs+strict) +
-  `npx tsc --noEmit` (typescript already comes via ts-morph) + ESLint flat config;
-  fail CI on either. *(tests/medium)*
-- [ ] **Coverage floor** — run under c8 in CI, enforce e.g. `--lines 70` so
-  unexecuted shipped files stay visible. *(tests/medium)*
-- [ ] **Test env isolation** — `test/install-skill.test.mjs:84`: `--global` tests
+- [x] **Lint/typecheck gate** — **typecheck DONE; ESLint deliberately NOT adopted;
+  the item's dependency premise was wrong.** "typescript already comes via ts-morph"
+  is false: `@ts-morph/common` **vendors** the compiler and exposes no `tsc` bin, so
+  this required adding `typescript` + `@types/node` as **dev** dependencies. That is
+  compatible with the near-zero-deps rule as written — it governs *runtime* deps and
+  the tarball, and `package.json` `files` is an allowlist, confirmed by
+  `npm pack --dry-run`.
+  **`strict` is OFF, measured, not conceded:** strict reports **505** errors, 272 of
+  them TS7006 ("annotate this parameter") — a rewrite, not a gate. Non-strict
+  reported **2**, and both were real drift: a JSDoc `@type` for `PLATFORMS` that had
+  fallen behind the object it describes (`codexHooks` missing, while the code reads
+  it), and a dynamic `import()` of a `URL` object TypeScript cannot follow. Both
+  fixed; the gate is clean and runs on every OS in the matrix.
+  Also verified that adding a `jsconfig.json` to agentmap's own root does not
+  perturb its self-map — byte-identical with and without it, which matters because
+  agentmap reads `jsconfig.json` when mapping a repo.
+  **ESLint: no.** Its remaining value here is stylistic — the correctness class it
+  would catch is what `checkJs` now covers — and it is a large dependency tree plus
+  a config to maintain, on a repo whose identity is near-zero-deps. Reconsider only
+  with outside contributors, where a shared style gate saves review time.
+  *(tests/medium)*
+- [x] **Coverage floor** — DONE, **without c8**: `node --test` ships coverage and
+  threshold flags natively from Node 22, so `npm run coverage` needs no dependency at
+  all. Its own CI job pinned to Node 24, because the flags do not exist on Node 20,
+  which the test matrix still supports. Measured **93.77% lines / 76.12% branches**;
+  floors set at **90/70**, deliberately *below* current — a gate pinned to today's
+  number reddens on ordinary work and gets raised until nobody reads it. This is a
+  regression alarm, not a target. *(tests/medium)*
+- [x] **Test env isolation** — `test/install-skill.test.mjs:84`: `--global` tests
   hit the real `$HOME`; git tests inherit host git config. Add `opts.env` to
   `helpers.run()`, route through a fake HOME, set `GIT_CONFIG_GLOBAL=/dev/null`.
   *(tests/low)*
@@ -512,53 +571,82 @@ post-distribution demand asks for Python (Batch 2's seam makes it a 1–2 week a
 - [x] **Claude nudge npx path** — `hooks/agentmap-nudge.mjs:116` tells the agent to
   run a `node_modules/...` path that doesn't exist for npx/global installs.
   Recommend `npx @raymondchins/agentmap --any` (as the Gemini nudge does). *(medium)*
-- [ ] **Windows global Gemini path** — `skills/install.mjs:75` writes to
+- [x] **Windows global Gemini path** — `skills/install.mjs:75` writes to
   `~/.agents/GEMINI.md`, which Gemini CLI never reads. Drop the win32 special case.
   *(medium)*
-- [ ] **`--symbols N` silent cap** — `agentmap.mjs:1780` caps at 80 while claiming
+- [x] **`--symbols N` silent cap** — `agentmap.mjs:1780` caps at 80 while claiming
   N. Recompute or clamp the printed count with a note. *(low)*
-- [ ] **Installer robustness** — `skills/install-helpers.mjs:83`: opaque TypeError
+- [x] **Installer robustness** — `skills/install-helpers.mjs:83`: opaque TypeError
   when an existing `hooks` key isn't an array → partial install. Validate shapes
   up front; validate all platforms before writing any file. *(low)*
-- [ ] **JSONC comment preservation** — `skills/install-helpers.mjs:104`: rewriting
+- [x] **JSONC comment preservation** — `skills/install-helpers.mjs:104`: rewriting
   `settings.json` strips comments silently. Surgical splice, or warn. *(low)*
 
 ### Docs / benchmark honesty
-- [ ] **Benchmark headline** — `README.md:63`: only Scenario F's skew is disclosed;
+- [x] **Benchmark headline** — `README.md:63`: only Scenario F's skew is disclosed;
   Scenario D also inflates the total (excluding both → ~89.8% / ~10× on ai-chatbot).
   Add the D+F-excluded figure; validate chars/4 once against a real tokenizer; re-run
   `npm run eval` post-0.8.0 and refresh dates/numbers. *(medium)*
-- [ ] **Blast-radius row footnote** — `benchmark/RESULTS.md:26`: the 99.2% row is
+- [x] **Blast-radius row footnote** — `benchmark/RESULTS.md:26`: the 99.2% row is
   contradicted by EVAL.md (agentmap wins precision, loses tokens vs `grep -l`).
   Footnote it or add a `grep -l` baseline to `bench.mjs`. *(high, docs-only)*
-- [ ] **Onboarding matrix + uninstall + troubleshooting** — `README.md:223`: add a
+- [x] **Onboarding matrix + uninstall + troubleshooting** — `README.md:223`: add a
   per-CLI "commands to full loop / enforcement vs docs-only" matrix, a copy-paste
   `.cursor/mcp.json`, an **Uninstall** section listing every file the installers
   touch (there's no `--uninstall` command — consider adding one), and a
   Troubleshooting section (nvm PATH, 0-files-mapped, stale skills via `--doctor`).
   *(medium)*
-- [ ] **Benchmark realism** — `benchmark/bench.mjs:26`: add wall-clock (cold/warm/
-  dirty), include a 3–5k-file repo, report the excluding-F total. *(low)*
-- [ ] **Competitor table** — `README.md:101`: Batch 1 fixed Aider's install; still
+- [~] **Benchmark realism** — `benchmark/bench.mjs`: **the excluding-F total is
+  DONE** (see the Benchmark-headline item above — `RESULTS.md` now carries an
+  `Excl. D+F` column per repo plus a pooled row, and the D+F skew is stated in the
+  README). Still open: wall-clock (cold/warm/dirty) and a 3–5k-file fixture, both of
+  which need a new pinned repo and a change to what `bench.mjs` measures rather than
+  how it reports. *(low)*
+- [x] **Competitor table** — `README.md:101`: Batch 1 fixed Aider's install; still
   update Repomix's agent-loop cell to "MCP server (no auto-refresh/nudge)", link
   every row to its repo, add an "as of \<date\>" footnote. *(low)*
 
 ### Housekeeping (from the completeness critic)
-- [ ] Dead `statSync` import (`agentmap.mjs:16`); `readPackageVersion` implemented
-  4× with divergent failure behavior — unify once modularized. *(low)*
-- [ ] Duplicated recursive dir walk between `sourceFingerprint()` and `makeProject()`
-  (`agentmap.mjs:431`) — extract one `walkSources()`. *(low)*
+- [x] Dead `statSync` import (`agentmap.mjs:16`); `readPackageVersion` implemented
+  4× with divergent failure behavior. **Both were already fixed and only the
+  checkbox was stale** — verified 2026-07-27: `statSync` is absent from the import
+  list, and `readPackageVersion` is one definition with two callers plus an export,
+  not four divergent copies. *(low)*
+- [x] Duplicated recursive dir walk between `sourceFingerprint()` and `makeProject()`
+  — extracted as `walkSources(dir, onFile)`. The two copies were identical except
+  for the leaf action, with four load-bearing, non-obvious safety rules restated in
+  both (depth cap 40, per-directory try/catch, `lstatSync` not `statSync`, skip
+  symlinks) — so a fix could land in one and not the other. The reasoning for each
+  rule now lives once, at the shared function. Verified rather than assumed: 43
+  vue-sfc tests green, a tree containing a circular *and* a dangling symlink still
+  terminates with exit 0, and a non-git `.vue` tree still resolves its import
+  edge. *(low)*
 - [x] Node 18 is past EOL (Apr 2025) but in `engines` + CI matrix — decide support
   policy. Resolved: `engines` is `>=20` and the matrix is `[20, 22, 24]`. The floor
   is set by the dependency tree, not by EOL dates — `brace-expansion` (via ts-morph
   → @ts-morph/common → minimatch) declares `20 || >=22`, so `>=18` was a claim the
   tree contradicted. `dependabot.yml` now covers npm + Actions, with `ts-morph` on
   the weekly update path.
-- [ ] Community health files: no `.github/ISSUE_TEMPLATE`, PR template,
-  `CODE_OF_CONDUCT.md`, `FUNDING.yml`. CI Actions pinned by mutable tags (`@v5`),
-  not SHA — a hardening gap the SECURITY.md advertises.
-- [ ] Consider a neutral `.agentmap/` cache path (currently `.claude/agentmap/`
-  even for Gemini/Codex/Cursor users) with back-compat.
+- [~] Community health files. **Mostly done; one item deliberately left to the
+  maintainer.** `.github/ISSUE_TEMPLATE/` and `PULL_REQUEST_TEMPLATE.md` already
+  existed, and CI Actions are already SHA-pinned (`@3d3c42e5…`, `@820762786…`,
+  `@e4fba868…`, `@e0c47f4f…`) — that half of the finding was stale.
+  `CODE_OF_CONDUCT.md` added: it links the Contributor Covenant rather than copying
+  a text that would then drift, and says explicitly that being told a patch is wrong,
+  or that a number does not reproduce, is the process working — this roadmap closes
+  items as *refuted* in writing, and that norm should be stated rather than
+  discovered. **No `FUNDING.yml`:** sponsorship handles are the maintainer's call
+  and are not something to invent on their behalf.
+- [x] Consider a neutral `.agentmap/` cache path (currently `.claude/agentmap/`
+  even for Gemini/Codex/Cursor users). **DECIDED: no.** The complaint is real — the
+  path names one vendor and every other platform's users inherit it — but it is
+  cosmetic, and the change is not. `.claude/agentmap/` is written by the post-commit
+  hook in every consumer repo, gitignored by `--install-hooks`, read by `--doctor`,
+  and named across README, SECURITY.md and hooks/INSTALL.md. Moving it means a
+  dual-read back-compat path that must then be carried indefinitely, on a tool whose
+  central invariant is that a query never returns a stale map — i.e. new ways to
+  read the wrong cache, bought with no capability. Recorded so it is not reopened
+  from scratch; reconsider only if a platform actually refuses the path.
 - [x] `--export dot|mermaid` — file import graph → Graphviz DOT / Mermaid, top-N by
   pagerank, 3 style tiers, `--focus` scopes to a neighborhood; reads the cached map
   (no ts-morph Project). (Call-graph closure export = future v2.)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -232,10 +232,20 @@ behavior into a real competitive claim vs CodeGraph's 2s sync.
     `./types` → `types.d.ts`, and for directory imports resolving via a nested
     `package.json` `"main"`. Trying ts-morph first with `resolveSpec` as fallback is
     already the correct design. *(performance/high)*
-- [ ] **Incremental post-commit rebuild + lock** — `hooks/post-commit:67`: the
-  hook re-parses the entire repo on every commit and concurrent rebuilds duplicate
-  work with no locking. Diff `HEAD~1..HEAD` and re-parse only changed files + their
-  direct dependents; add a lockfile / compare-and-skip on in-progress HEAD build.
+- [~] **Incremental post-commit rebuild + lock** — **LOCK DONE; incremental
+  deliberately NOT taken yet.** The locking half shipped: `hooks/post-commit` holds
+  a single-instance lock via atomic `mkdir` (`:92`), clears a lock orphaned by a
+  killed run after 10 minutes (`:95`) so one bad commit cannot wedge refresh
+  permanently, and caps the run with a process-tree kill. Concurrent rebuilds no
+  longer duplicate work.
+  The incremental half is **gated on Tier 2 going default-on**, and should stay
+  gated. Tier 2 (`AGENTMAP_INCREMENTAL=1`) is still EXPERIMENTAL because three
+  adversarial rounds left a residual isolated-reparse tail (`.d.ts` edges,
+  package.json `exports`, barrel+target). This hook ships to every consumer and runs
+  on every commit they make, so wiring it to an opt-in-because-not-yet-trusted path
+  would push exactly that tail onto people who never opted in — and a wrong map
+  written by a background hook is the hardest kind to notice. Revisit when Tier 2's
+  tail closes and it becomes the default dirty path.
   *(performance/medium — depends on Batch 2 incremental machinery)*
 - [ ] **Memory ceiling** — ⚠ **THE REMEDY IN THE ORIGINAL ITEM IS REFUTED. Do not
   implement it.** Measured on content-os (393 files), four loop variants doing
@@ -256,19 +266,50 @@ behavior into a real competitive claim vs CodeGraph's 2s sync.
   closure (~300MB, ~1,800 extra program files on content-os) dominates and is
   independent of repo size. A file-count envelope would cry wolf on small dep-heavy
   repos and stay silent on the big repo it exists for.
-  **Still open, rescoped:** sample real `heapUsed` during the parse and print one
-  actionable warning (with the `--max-old-space-size` fix) before an OOM kills the
-  build with no map at all; document the measured envelope. *(performance/medium)*
+  **The rescoped remedy is now ALSO refuted — built, measured, reverted.** Sampling
+  `heapUsed` against `getHeapStatistics().heap_size_limit` during the parse loop
+  cannot fire in time, for two independent reasons measured on zod (409 files) under
+  a forced `--max-old-space-size=150`:
+  - **The fatal allocation is inside ONE file's work, not spread across files.** With
+    a probe printing on every iteration, the process died having logged **exactly one
+    sample** — it OOM'd during the first file's `getExportedDeclarations()`. Sampling
+    every 64 files logged **zero** samples before death. No sampling rate helps when
+    the granularity of the blow-up is finer than one loop iteration.
+  - **The reading immediately before death is not elevated.** That single sample read
+    `heapUsed` **104MB against a 246MB limit — 42%**, nowhere near any threshold
+    worth warning on. V8 keeps `heapUsed` low by collecting harder right up until it
+    gives up, so the ratio is flat and then the process is gone.
+  A guard that never fires is worse than none: it reads as protection in the source
+  and in a review. The implementation was therefore reverted (`agentmap.mjs` is
+  byte-identical to before it), and what survives is the half that is real — the
+  measured envelope and the `--max-old-space-size` remedy, documented in the README
+  Troubleshooting section where a user hitting the OOM will search for it.
+  **Still open:** nothing in-process. A supervisor that spawns the build and maps
+  exit 134 / `SIGABRT` to the remedy would work, and `mcp.mjs` already spawns
+  agentmap so it could do this for the MCP path — but the plain CLI has no parent,
+  and adding one is an architecture change, not a warning. *(performance/medium)*
 - [x] **Cap unbounded symbol matches** — DONE. `--find`/`--any` symbol matches are
   ranked by the containing file's PageRank and capped to `SYMBOL_MATCH_LIMIT` (50),
   with a "showing top N of M by pagerank — narrow your query" footer in prose and
   `total`/`shown`/`truncated` (`--find`) / `symbolsTotal`/`symbolsTruncated`
   (`--any`) in JSON. Ranking keeps the important matches when truncated.
   *(performance/medium)*
-- [ ] **Prune rankSymbols cross-product** — `agentmap.mjs:736`: refs×defs edge
-  list per identifier is quadratic on duplicated export names. Skip identifiers
-  whose definer count exceeds a threshold (near-zero signal after the 0.1
-  multiplier) or aggregate into per-defFile summary edges. *(performance/low)*
+- [x] **Prune rankSymbols cross-product** — **CLOSED: REFUTED. Do not implement.**
+  Measured on five repos (agentmap 77 files, zustand 49, hono 385, zod 409,
+  a 392-file Next.js app) by replaying the edge-building loop over each cached map.
+  The cross-product is not quadratic in practice: the largest edge list is **2,533**
+  (hono), and the most definers any single identifier attracts is **17**. Pruning at
+  `defCount > 20` drops **0 edges on every one of the five**, so the threshold the
+  item implies is a no-op. Pruning low enough to matter is actively harmful —
+  `defCount > 5` would drop **78.7% of zod's graph**, including `util`
+  (12 definers × 34 referencing files), which is a real identifier the ranking wants.
+  The app-shaped repo, the case most likely to duplicate export names, peaked at
+  **3** definers (`NotificationsPage`) and 1,292 edges.
+  Two premises were wrong: `default` is already excluded from references
+  (`agentmap.mjs:1859`), which removes the one identifier that would genuinely fan
+  out, and `identMul`'s `RARE_PENALTY` already discounts the high-definer case it
+  proposed to delete. The real cost driver is `getExportedDeclarations()` at
+  ~O(N^2.7), recorded in the wall-clock-budget item above. *(performance/low)*
 
 **Acceptance:** a second query on an unchanged dirty tree does not re-parse;
 a pathological deep-chain repo finishes within the budget with skipped files

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -56,6 +56,13 @@ When no graph match is found, agentmap falls back to a live `git grep` over trac
 
 This denylist is a best-effort guard for conventionally-named secret files, not a guarantee — a secret stored in an unmatched filename can still be surfaced. (It deliberately does **not** match a bare `token` substring, which would over-exclude ordinary source like `tokenizer.ts`.) agentmap does **not** transmit file contents anywhere; all processing is local.
 
+**Matched lines are untrusted repository bytes**, and are the only place agentmap echoes repository content back out — everything else it prints is its own metadata. Two guards apply:
+
+- **Terminal control sequences are neutralised.** C0 control characters and `DEL` are replaced with `U+FFFD` before the lines are printed or serialised, on both the prose and `--json` surfaces. Tab and newline are preserved. Without this, a text file carrying `ESC[2J` or a cursor-up run could blank the terminal or overwrite the `file:line` prefix so a hit appears to come from a file it did not.
+- **Over MCP, the lines are fenced as data.** The `any` tool appends a second content block marking the result as raw untrusted repository content, so a planted "ignore previous instructions" in an ordinary source or markdown file reads to the model as data rather than as a command. Structural results (file / symbol / feature) are agentmap's own metadata and are not fenced; the CLI path writes to a terminal, not to a model, and is not fenced either.
+
+Neither guard makes untrusted repository content safe to execute. They reduce the two ways a matched line can act on something other than the reader's eyes.
+
 ### Trust boundaries
 
 | Boundary | Notes |

--- a/agentmap.mjs
+++ b/agentmap.mjs
@@ -277,9 +277,23 @@ const SENSITIVE_EXCLUDES = [
   // password.txt / passwords.json is excluded, not just foo.password.ts.
   ":(exclude,icase)*secret*", ":(exclude,icase)*credential*", ":(exclude,icase)*password*",
 ];
+// Neutralise terminal control sequences in content-search output. These lines are
+// the ONLY place agentmap echoes raw repository bytes back out — everything else it
+// prints is its own metadata. `git grep -I` already skips binary files, so what is
+// left is a TEXT file with escapes deliberately embedded in it: an ESC[2J or a
+// cursor-up run can blank the terminal or overwrite the file:line prefix, making a
+// hit appear to come from a file it did not. Replaces C0 controls (keeping \t) and
+// DEL with U+FFFD, so the line count and column alignment survive and the escape
+// becomes visible instead of executable. Applied inside contentSearch() rather than
+// at the two print sites, so prose AND --json get the same sanitised bytes — a JSON
+// consumer that parses and echoes a line is exposed to exactly the same trick, and
+// MCP's JSON.stringify escaping protects the model but not that consumer.
+// eslint-disable-next-line no-control-regex
+const CONTROL_CHARS = /[\x00-\x08\x0B-\x1F\x7F]/g;
+const sanitizeContentLines = (s) => s.replace(CONTROL_CHARS, "�");
 const contentSearch = (q) => {
   try {
-    return execFileSync("git", ["-c", "core.quotePath=off", "grep", "-F", "--untracked", "-n", "-i", "-I", "-e", q, "--", ".", ":!.claude/agentmap/", ...SENSITIVE_EXCLUDES], { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"], maxBuffer: MAXBUF }).trim();
+    return sanitizeContentLines(execFileSync("git", ["-c", "core.quotePath=off", "grep", "-F", "--untracked", "-n", "-i", "-I", "-e", q, "--", ".", ":!.claude/agentmap/", ...SENSITIVE_EXCLUDES], { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"], maxBuffer: MAXBUF }).trim());
   } catch { return ""; }
 };
 const currentSha = () => sh("git rev-parse --short HEAD");

--- a/agentmap.mjs
+++ b/agentmap.mjs
@@ -3048,7 +3048,10 @@ async function main() {
   // `node mcp.mjs` run, which is not cyclic).
   if (has("--mcp")) {
     try {
-      const m = await import(new URL("./mcp.mjs", import.meta.url));
+      // .href, not the URL object: both resolve identically at runtime, but the
+      // dynamic-import signature is typed as string, so the object form is the
+      // one thing in this file the typecheck gate cannot see past.
+      const m = await import(new URL("./mcp.mjs", import.meta.url).href);
       await m.serve(mcpQuery);
     } catch (e) {
       console.error(`agentmap --mcp failed: ${e?.message || e}`);

--- a/agentmap.mjs
+++ b/agentmap.mjs
@@ -1818,6 +1818,27 @@ function assemble(files, { target = MAP, extra = null, t0 = Date.now() } = {}) {
   return out;
 }
 
+// Resolve `--symbols n` / the `symbols` MCP tool against a cached map.
+//
+// `map.json` persists only the top RANKED_SYMBOLS_LIMIT (80) symbols, so asking
+// for more used to print "top 200 ranked symbols" above at most 80 rows: the
+// count described the REQUEST, not the output, with nothing saying so. When n
+// exceeds what was persisted, re-rank from the cached file map rather than
+// truncating — rankSymbols() reads `files` only, which is the same ts-morph-free
+// recompute the `--map --focus` path already performs, so this costs a graph walk
+// over data already in memory and no rebuild. Falls back to the stored slice if
+// the recompute cannot run (a pre-schema-7 cache with no `files`), because a
+// short answer beats a thrown one. Callers report `shown` so a repo that simply
+// has fewer ranked symbols than requested is distinguishable from a cap.
+function rankedSymbolsFor(data, n) {
+  const stored = data.rankedSymbols || [];
+  if (n <= stored.length) return stored.slice(0, n);
+  try {
+    const full = rankSymbols(data.files || {}, null);
+    return full.length >= stored.length ? full.slice(0, n) : stored.slice(0, n);
+  } catch { return stored.slice(0, n); }
+}
+
 // Build the Aider-style identifier graph from the file map and return a
 // ranked list of { file, name, kind, rank }. `focus` (Set of paths) +
 // derived mentioned idents personalize the ranking when given.
@@ -3400,9 +3421,9 @@ async function main() {
   } else if (has("--symbols")) {
     const data = ensureFresh();
     const sn = parseInt(arg("--symbols") ?? "", 10); const n = Number.isFinite(sn) && sn > 0 ? sn : DEFAULT_SYMBOLS;
-    const syms = (data.rankedSymbols || []).slice(0, n);
-    out({ command: "symbols", symbols: syms.map((s) => ({ rank: s.rank, file: s.file, name: s.name, kind: s.kind })) }, () => {
-      console.log(`top ${n} ranked symbols (Aider-style):`);
+    const syms = rankedSymbolsFor(data, n);
+    out({ command: "symbols", requested: n, shown: syms.length, truncated: syms.length < n, symbols: syms.map((s) => ({ rank: s.rank, file: s.file, name: s.name, kind: s.kind })) }, () => {
+      console.log(`top ${syms.length} ranked symbols (Aider-style)${syms.length < n ? ` — asked for ${n}, this repo only ranks ${syms.length}` : ""}:`);
       for (const s of syms) console.log(`  ${s.rank}  ${s.file} → ${s.name} (${s.kind})`);
     });
   } else if (has("--feature")) {
@@ -4487,8 +4508,8 @@ function mcpQuery(name, args) {
       const data = mcpEnsureFresh();
       const snRaw = (a.n != null && Number.isFinite(Number(a.n))) ? String(Math.trunc(Number(a.n))) : "";
       const sn = parseInt(snRaw, 10); const n = Number.isFinite(sn) && sn > 0 ? sn : DEFAULT_SYMBOLS;
-      const syms = (data.rankedSymbols || []).slice(0, n);
-      return ok({ command: "symbols", symbols: syms.map((s) => ({ rank: s.rank, file: s.file, name: s.name, kind: s.kind })) });
+      const syms = rankedSymbolsFor(data, n);
+      return ok({ command: "symbols", requested: n, shown: syms.length, truncated: syms.length < n, symbols: syms.map((s) => ({ rank: s.rank, file: s.file, name: s.name, kind: s.kind })) });
     }
     default:
       return err(2, `unknown tool: ${name}`);

--- a/agentmap.mjs
+++ b/agentmap.mjs
@@ -438,30 +438,39 @@ function bm25Search(lexical, files, rawQuery, { limit = SYMBOL_MATCH_LIMIT } = {
 // without a full reparse. Skips node_modules/.git/.next. Any error ⇒ "" (caller
 // falls through to build, i.e. current behavior). Never used on the git path.
 // SOURCE_EXT_RE includes `.vue` so editing a Vue SFC invalidates the cache too.
+// The one recursive source walk. Two callers needed exactly this traversal and
+// differed only in what they do with a file, so it existed twice with the safety
+// rules restated in both — the failure mode being a fix applied to one copy. The
+// rules are load-bearing and each is here for a specific reason:
+//   • depth cap 40 — don't fully walk a pathologically deep tree;
+//   • per-directory try/catch — one permission-denied subdir must NOT abort the
+//     WHOLE walk. In sourceFingerprint() that would return "" and silently
+//     disable caching, which looks like a performance mystery, not an error;
+//   • lstatSync, NOT statSync, so a symlink reports as itself rather than its
+//     target, and symlinked entries are skipped entirely — never recursed into,
+//     never stat'd through — so a circular symlink cannot recurse until the
+//     stack overflows;
+//   • node_modules/.git/.next pruned before any stat.
+// `onFile(fullPath, name, stat)` is called for every non-directory survivor.
+function walkSources(dir, onFile, depth = 0) {
+  if (depth > 40) return;
+  let names; try { names = readdirSync(dir); } catch { return; }
+  for (const name of names) {
+    if (name === "node_modules" || name === ".git" || name === ".next") continue;
+    const full = dir + "/" + name;
+    let st; try { st = lstatSync(full); } catch { continue; }
+    if (st.isSymbolicLink()) continue;
+    if (st.isDirectory()) walkSources(full, onFile, depth + 1);
+    else onFile(full, name, st);
+  }
+}
+
 function sourceFingerprint() {
   try {
     const entries = [];
-    const walk = (dir, depth) => {
-      if (depth > 40) return; // depth cap — don't fully walk a pathologically deep tree
-      // per-directory try/catch: a single permission-denied subdir must NOT abort
-      // the WHOLE walk (that would return "" and silently disable caching) — skip
-      // the unreadable dir and keep going so the fingerprint stays usable.
-      let names; try { names = readdirSync(dir); } catch { return; }
-      for (const name of names) {
-        if (name === "node_modules" || name === ".git" || name === ".next") continue;
-        const full = dir + "/" + name;
-        let st;
-        // lstatSync (NOT statSync) so a symlink reports as a symlink instead of
-        // its target. Symlinked entries are SKIPPED entirely — never recursed
-        // into, never stat'd through — so a circular symlink can't cause infinite
-        // recursion / stack overflow.
-        try { st = lstatSync(full); } catch { continue; }
-        if (st.isSymbolicLink()) continue;
-        if (st.isDirectory()) walk(full, depth + 1);
-        else if (SOURCE_EXT_RE.test(name)) entries.push(`${full}:${st.mtimeMs}:${st.size}`);
-      }
-    };
-    walk(".", 0);
+    walkSources(".", (full, name, st) => {
+      if (SOURCE_EXT_RE.test(name)) entries.push(`${full}:${st.mtimeMs}:${st.size}`);
+    });
     entries.sort();
     return createHash("sha1").update(entries.join("\n")).digest("hex");
   } catch { return ""; }
@@ -1150,23 +1159,11 @@ function makeProject(inc = null) {
       `components/**/*.${g}`, `lib/**/*.${g}`,
       `pages/**/*.${g}`, `*.${g}`,
     ]);
-    // Non-git `.vue` fallback: walk the tree like sourceFingerprint() does.
+    // Non-git `.vue` fallback: same traversal as sourceFingerprint(), different leaf.
     try {
-      const walk = (dir, depth) => {
-        if (depth > 40) return; // depth cap, matching sourceFingerprint()
-        let names; try { names = readdirSync(dir); } catch { return; } // skip unreadable dir, don't abort the whole walk
-        for (const name of names) {
-          if (name === "node_modules" || name === ".git" || name === ".next") continue;
-          const full = dir + "/" + name;
-          // lstatSync (NOT statSync) + skip symlinks, matching sourceFingerprint():
-          // a circular symlink would otherwise recurse until the stack overflows.
-          let st; try { st = lstatSync(full); } catch { continue; }
-          if (st.isSymbolicLink()) continue;
-          if (st.isDirectory()) walk(full, depth + 1);
-          else if (name.endsWith(".vue")) vueFiles.push(full.replace(/^\.\//, ""));
-        }
-      };
-      walk(".", 0);
+      walkSources(".", (full, name) => {
+        if (name.endsWith(".vue")) vueFiles.push(full.replace(/^\.\//, ""));
+      });
     } catch { /* ignore — proceed without Vue */ }
   }
   // Build the virtual→real map and register each `<script>` block as a virtual

--- a/benchmark/RESULTS.md
+++ b/benchmark/RESULTS.md
@@ -6,13 +6,21 @@ raw files with `cat` / `grep` / `find`. Measured across **7 agent tasks on 3 rea
 public repos**, fully reproducible. Every number below is captured tool output —
 no hand-tuned figures.
 
-| Repo | Files | Total saved | Standout task |
-|------|------:|------------:|---------------|
-| [vercel/ai-chatbot](https://github.com/vercel/ai-chatbot) | 154 | **98.3%** | reuse lookup 99.9% |
-| [colinhacks/zod](https://github.com/colinhacks/zod) | 367 | **99.2%** | whole-repo map 99.8% |
-| [shadcn-ui/taxonomy](https://github.com/shadcn-ui/taxonomy) | 125 | **96.0%** | reuse lookup 99.3% |
+| Repo | Files | Total saved | Excl. D+F | Standout task |
+|------|------:|------------:|----------:|---------------|
+| [vercel/ai-chatbot](https://github.com/vercel/ai-chatbot) | 154 | **98.3%** | 89.8% | reuse lookup 99.9% |
+| [colinhacks/zod](https://github.com/colinhacks/zod) | 367 | **99.2%** | 96.4% | whole-repo map 99.8% |
+| [shadcn-ui/taxonomy](https://github.com/shadcn-ui/taxonomy) | 125 | **96.0%** | 73.1% | reuse lookup 99.3% |
+| **Pooled** | 646 | **98.7%** | **93.7%** | — |
 
 Per-task peaks across the three repos: **whole-repo map 99.8%**, **reuse-before-rebuild 99.9%**, **blast-radius 99.2%**, **find-symbol 99%**.
+
+**Read the second column before quoting the first.** Scenarios **D** (blast radius) and
+**F** (map whole repo) are the two largest rows in every run, and they carry the totals —
+see caveats 7 and 8. The `Excl. D+F` column is the same runs with both dropped: it is the
+figure to quote for the *routine* case, and the totals are the figure for the case the tool
+exists to prevent (an agent dumping a repo into context). Both columns come from the same
+captured output below; neither is re-weighted.
 
 ## Captured runs (`bench.mjs`)
 
@@ -73,9 +81,18 @@ ts-morph-mappable repo.
 ## Honest caveats — read before quoting the number
 
 1. **Token estimate is `chars / 4`** — a rough heuristic (the same one agentmap
-   uses), applied to **both** sides, so the saved-% *ratio* is robust even though
-   absolute token figures are ±10%. Raw char counts live in each run's `@@JSON@@`
-   footer.
+   uses), applied to **both** sides. **Checked once against a real tokenizer**
+   (`o200k_base`, 2026-07-27, on the three pinned `EVAL.md` repos): `chars/4`
+   **undercounts** real tokens by **1.1–12.5%** on raw source, and is within
+   **±4.6%** on agentmap's own `--map`/`--hubs` output. So the *absolute* counts
+   are looser than the ±10% this caveat used to claim — treat them as ±13%.
+   The *ratio* survives, which is the part that gets published: agentmap's output
+   tokenizes ~4–10% more densely than raw source, and recomputing the saved-% on
+   real tokens moves it by **0.03–0.08 percentage points** (zod 99.6 → 99.7,
+   hono 99.6 → 99.6, zustand 98.0 → 98.1). Quote the percentages, not the counts.
+   The tokenizer is **not** a dependency — it was installed once outside the repo
+   for this check and nothing in `package.json` changed. Raw char counts live in
+   each run's `@@JSON@@` footer.
 2. **One result is negative, and we left it in.** taxonomy scenario **A = −313%**:
    for a *trivial single-file* dependency lookup, `cat` + a tiny `grep` is cheaper
    than agentmap's structured block. The tool pays off **at scale** (more files,
@@ -93,6 +110,24 @@ ts-morph-mappable repo.
    there (unusual layout its ts-morph pass didn't pick up), so `--map` emitted
    nothing and the "100%" was an empty-output artifact, not a real saving. Only
    repos agentmap actually indexes are reported.
+7. **Two scenarios carry the totals.** D and F are the two largest rows in all
+   three runs — on ai-chatbot they are 90% of the baseline by themselves. Dropping
+   both takes 98.3% → **89.8%** (ai-chatbot), 99.2% → **96.4%** (zod), and
+   96.0% → **73.1%** (taxonomy); pooled, 98.7% → **93.7%**. That is not a
+   correction — a repo dump and a blast-radius walk are things agents really do,
+   and they are exactly where a map wins most. It does mean a total is a statement
+   about a *mix of tasks*, so quoting it for a single routine query overstates it.
+   The `Excl. D+F` column exists so nobody has to recompute this to check.
+8. **Scenario D's baseline is `cat` every dependent, not `grep -l`.** The 99.2% is
+   measured against an agent that opens all 65 dependent files. Against an agent
+   that runs `grep -l` and reads nothing, `--relates` costs **more** tokens, not
+   fewer — [`../EVAL.md`](../EVAL.md) measures and states that. The two are not in
+   conflict; they price different baselines. What the eval adds is why the cheaper
+   baseline is not free: `grep -l` scores **59.9%** precision against agentmap's
+   **100%** (n=42), so roughly 4 in 10 files on that list are not dependents, and
+   the agent pays for them on the next turn when it reads them. ⚠️ `bench.mjs` does
+   **not** yet ship a `grep -l` baseline row for D — until it does, this caveat is
+   the reconciliation, not a measured third column.
 
 ## Reproduce
 

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,29 @@
+{
+  "//": [
+    "Typecheck gate for a codebase with no .ts in it. agentmap.mjs is ~250KB of",
+    "hand-written JavaScript; `checkJs` is the only static analysis that reads it.",
+    "",
+    "strict is OFF on purpose, and that is the whole reason this file is usable.",
+    "Measured 2026-07-27: strict reports 505 errors, of which 272 are TS7006",
+    "(annotate every parameter) — a rewrite, not a gate. Non-strict reports 2, and",
+    "both were real drift: a JSDoc @type for PLATFORMS that had fallen behind the",
+    "object it describes, and a dynamic import TypeScript could not follow. The",
+    "gate earns its place by catching that class — wrong property, wrong arity,",
+    "stale annotation — not by demanding annotations.",
+    "",
+    "Tighten it when the code is ready, not by loosening what it reports."
+  ],
+  "compilerOptions": {
+    "checkJs": true,
+    "allowJs": true,
+    "noEmit": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": false,
+    "noImplicitAny": false,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["agentmap.mjs", "mcp.mjs", "skills/*.mjs", "hooks/*.mjs"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,22 @@
 {
   "name": "@raymondchins/agentmap",
-  "version": "0.17.0",
+  "version": "0.20.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@raymondchins/agentmap",
-      "version": "0.17.0",
+      "version": "0.20.1",
       "license": "MIT",
       "dependencies": {
         "ts-morph": "28.0.0"
       },
       "bin": {
         "agentmap": "agentmap.mjs"
+      },
+      "devDependencies": {
+        "@types/node": "^26.1.1",
+        "typescript": "^7.0.2"
       },
       "engines": {
         "node": ">=20"
@@ -27,6 +31,356 @@
         "minimatch": "^10.0.1",
         "path-browserify": "^1.0.1",
         "tinyglobby": "^0.2.14"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@typescript/typescript-aix-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-loong64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-mips64el": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-riscv64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-s390x": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-sunos-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/balanced-match": {
@@ -131,6 +485,48 @@
         "@ts-morph/common": "~0.29.0",
         "code-block-writer": "^13.0.3"
       }
+    },
+    "node_modules/typescript": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc"
+      },
+      "engines": {
+        "node": ">=16.20.0"
+      },
+      "optionalDependencies": {
+        "@typescript/typescript-aix-ppc64": "7.0.2",
+        "@typescript/typescript-darwin-arm64": "7.0.2",
+        "@typescript/typescript-darwin-x64": "7.0.2",
+        "@typescript/typescript-freebsd-arm64": "7.0.2",
+        "@typescript/typescript-freebsd-x64": "7.0.2",
+        "@typescript/typescript-linux-arm": "7.0.2",
+        "@typescript/typescript-linux-arm64": "7.0.2",
+        "@typescript/typescript-linux-loong64": "7.0.2",
+        "@typescript/typescript-linux-mips64el": "7.0.2",
+        "@typescript/typescript-linux-ppc64": "7.0.2",
+        "@typescript/typescript-linux-riscv64": "7.0.2",
+        "@typescript/typescript-linux-s390x": "7.0.2",
+        "@typescript/typescript-linux-x64": "7.0.2",
+        "@typescript/typescript-netbsd-arm64": "7.0.2",
+        "@typescript/typescript-netbsd-x64": "7.0.2",
+        "@typescript/typescript-openbsd-arm64": "7.0.2",
+        "@typescript/typescript-openbsd-x64": "7.0.2",
+        "@typescript/typescript-sunos-x64": "7.0.2",
+        "@typescript/typescript-win32-arm64": "7.0.2",
+        "@typescript/typescript-win32-x64": "7.0.2"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
   "scripts": {
     "map": "node agentmap.mjs",
     "test": "node --test test/*.test.mjs test/**/*.test.mjs",
-    "eval": "node eval/eval.mjs"
+    "eval": "node eval/eval.mjs",
+    "typecheck": "tsc -p jsconfig.json",
+    "coverage": "node --test --experimental-test-coverage --test-coverage-lines=90 --test-coverage-branches=70 test/*.test.mjs test/**/*.test.mjs"
   },
   "engines": {
     "node": ">=20"
@@ -75,5 +77,9 @@
     "url": "https://github.com/raymondchins/agentmap/issues"
   },
   "author": "Raymond Surya Chin",
-  "license": "MIT"
+  "license": "MIT",
+  "devDependencies": {
+    "@types/node": "^26.1.1",
+    "typescript": "^7.0.2"
+  }
 }

--- a/skills/install-helpers.mjs
+++ b/skills/install-helpers.mjs
@@ -43,12 +43,38 @@ function stripJsonComments(src) {
   return out;
 }
 
+// Parse a settings file that may be JSONC. Returns { settings, hadComments } —
+// `hadComments` is true when the file only parsed after comments were stripped,
+// which is the caller's cue to warn: we re-serialise with JSON.stringify, so
+// every comment in the user's file is dropped on write. Preserving them would
+// mean a real JSONC-aware splice; warning is the honest cheap option, and it
+// beats the previous behaviour of deleting a user's annotations in silence.
 function parseSettings(text, settingsPath) {
-  try { return JSON.parse(text) || {}; }
+  try { return { settings: JSON.parse(text) || {}, hadComments: false }; }
   catch {
-    try { return JSON.parse(stripJsonComments(text)) || {}; }
+    try { return { settings: JSON.parse(stripJsonComments(text)) || {}, hadComments: /\/\/|\/\*/.test(text) }; }
     catch { throw new Error(`${settingsPath} is not valid JSON — fix or remove it, then re-run`); }
   }
+}
+
+// Fetch settings.hooks[event] as an array, creating it when absent and REJECTING
+// a conflicting shape with a message that names the file and the key.
+//
+// `settings.hooks ??= {}` only fills null/undefined, so a settings.json where
+// `hooks` is a string, a number or an array sailed through and blew up two lines
+// later on `.some is not a function` — an opaque TypeError, thrown mid-install
+// after earlier platforms had already been written to disk. The user saw a stack
+// trace and a half-installed skill, with nothing pointing at the actual cause.
+function hookArray(settings, event, settingsPath) {
+  if (settings.hooks === undefined || settings.hooks === null) settings.hooks = {};
+  if (typeof settings.hooks !== "object" || Array.isArray(settings.hooks)) {
+    throw new Error(`${settingsPath}: "hooks" must be an object, found ${Array.isArray(settings.hooks) ? "an array" : typeof settings.hooks} — fix it, then re-run`);
+  }
+  if (settings.hooks[event] === undefined || settings.hooks[event] === null) settings.hooks[event] = [];
+  if (!Array.isArray(settings.hooks[event])) {
+    throw new Error(`${settingsPath}: "hooks.${event}" must be an array, found ${typeof settings.hooks[event]} — fix it, then re-run`);
+  }
+  return settings.hooks[event];
 }
 
 export function readGuidanceSection() {
@@ -74,14 +100,17 @@ export function installGeminiHooks(root, dryRun) {
   const NUDGE_CMD = `node "$GEMINI_PROJECT_DIR/.gemini/hooks/agentmap-nudge.mjs"`;
   const targets = [nudgeRel, settingsPath];
 
-  let settings = {};
+  let settings = {}, hadComments = false;
   if (existsSync(settingsPath)) {
-    settings = parseSettings(readFileSync(settingsPath, "utf8"), settingsPath);
+    ({ settings, hadComments } = parseSettings(readFileSync(settingsPath, "utf8"), settingsPath));
   }
-  settings.hooks ??= {};
-  settings.hooks.BeforeTool ??= [];
+  // Validates shape and throws a named error before anything is written. Runs on
+  // the dry-run path too, on purpose: installSkill() preflights every platform
+  // with dryRun=true so a broken settings.json fails before the FIRST file lands,
+  // instead of halfway through a multi-platform install.
+  const beforeTool = hookArray(settings, "BeforeTool", settingsPath);
   const matcher = "run_shell_command|grep|search";
-  const already = settings.hooks.BeforeTool.some(
+  const already = beforeTool.some(
     (e) => e?.matcher === matcher && Array.isArray(e?.hooks) &&
       e.hooks.some((h) => typeof h?.command === "string" && h.command.includes("agentmap-nudge")),
   );
@@ -92,7 +121,7 @@ export function installGeminiHooks(root, dryRun) {
   writeFileSync(nudgeDest, readFileSync(GEMINI_NUDGE_SRC, "utf8"));
 
   if (!already) {
-    settings.hooks.BeforeTool.push({
+    beforeTool.push({
       matcher,
       hooks: [{
         name: "agentmap-nudge",
@@ -102,6 +131,12 @@ export function installGeminiHooks(root, dryRun) {
         description: "Nudge structural searches toward agentmap",
       }],
     });
+    // Say so before the rewrite, not after. JSON.stringify cannot round-trip
+    // JSONC, so the user's comments are about to be gone and the only kind thing
+    // to do is name the file they should check.
+    if (hadComments) {
+      console.warn(`  ⚠ ${settingsPath} contained comments — JSON has no way to keep them, so they were dropped when agentmap added its hook. Re-add them if you need them.`);
+    }
     atomicWrite(settingsPath, JSON.stringify(settings, null, 2) + "\n");
   }
   return targets;

--- a/skills/install.mjs
+++ b/skills/install.mjs
@@ -33,6 +33,7 @@ function skillPath(root, _globalScope, ...segments) {
  *   legacy?: boolean;
  *   docs?: (root: string, globalScope: boolean) => string;
  *   hooks?: boolean;
+ *   codexHooks?: boolean;
  *   plugin?: boolean;
  * }>} */
 const PLATFORMS = {

--- a/skills/install.mjs
+++ b/skills/install.mjs
@@ -2,7 +2,7 @@
 // --install-skill: skill files + always-on docs/hooks per platform (project or global).
 
 import { readFileSync, writeFileSync, existsSync } from "node:fs";
-import { homedir, platform as osPlatform } from "node:os";
+import { homedir } from "node:os";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
@@ -69,16 +69,17 @@ const PLATFORMS = {
   gemini: {
     label: "Gemini CLI",
     src: SKILL_MD,
-    dest: (root, globalScope) => {
-      if (!globalScope) return skillPath(root, false, ".gemini", "skills", "agentmap", "SKILL.md");
-      if (osPlatform() === "win32") return skillPath(root, true, ".agents", "skills", "agentmap", "SKILL.md");
-      return skillPath(root, true, ".gemini", "skills", "agentmap", "SKILL.md");
-    },
-    docs: (root, globalScope) => {
-      if (!globalScope) return join(root, "GEMINI.md");
-      if (osPlatform() === "win32") return join(root, ".agents", "GEMINI.md");
-      return join(root, ".gemini", "GEMINI.md");
-    },
+    // No win32 special case, deliberately. A previous version sent the GLOBAL
+    // Windows install to `~/.agents/` instead of `~/.gemini/`; `.agents` is the
+    // Amp/legacy convention (see the `agents` entry below), and Gemini CLI does
+    // not read it on any platform — it resolves global config under
+    // `homedir()/.gemini` everywhere. So the special case wrote two real files to
+    // a path nothing loads, and the install reported success: a Windows user got
+    // a silent no-op rather than an error. One path on every platform.
+    dest: (root, globalScope) =>
+      skillPath(root, globalScope, ".gemini", "skills", "agentmap", "SKILL.md"),
+    docs: (root, globalScope) =>
+      globalScope ? join(root, ".gemini", "GEMINI.md") : join(root, "GEMINI.md"),
     hooks: true,
   },
   antigravity: {
@@ -178,11 +179,11 @@ function installDocsForPlatform(cfg, { root, globalScope, dryRun, guidance, merg
   targets.push(dest);
 }
 
-function installExtrasForPlatform(name, cfg, { root, globalScope, dryRun, targets }) {
+function installExtrasForPlatform(name, cfg, { root, globalScope, dryRun, targets, quiet = false }) {
   if (cfg.hooks && !globalScope) {
     const hookTargets = installGeminiHooks(root, dryRun);
     for (const t of hookTargets) {
-      if (dryRun) console.log(`  ${cfg.label} hooks: ${t}`);
+      if (dryRun) { if (!quiet) console.log(`  ${cfg.label} hooks: ${t}`); }
       else {
         console.log(`  ${cfg.label} hooks → ${t}`);
         targets.push(t);
@@ -192,7 +193,7 @@ function installExtrasForPlatform(name, cfg, { root, globalScope, dryRun, target
   if (cfg.codexHooks && !globalScope) {
     const hookTargets = installCodexHooks(root, dryRun);
     for (const t of hookTargets) {
-      if (dryRun) console.log(`  ${cfg.label} hooks: ${t}`);
+      if (dryRun) { if (!quiet) console.log(`  ${cfg.label} hooks: ${t}`); }
       else {
         console.log(`  ${cfg.label} hooks → ${t}`);
         targets.push(t);
@@ -202,7 +203,7 @@ function installExtrasForPlatform(name, cfg, { root, globalScope, dryRun, target
   if (cfg.plugin && !globalScope) {
     const pluginTargets = installOpencodePlugin(root, dryRun);
     for (const t of pluginTargets) {
-      if (dryRun) console.log(`  ${cfg.label} plugin: ${t}`);
+      if (dryRun) { if (!quiet) console.log(`  ${cfg.label} plugin: ${t}`); }
       else {
         console.log(`  ${cfg.label} plugin → ${t}`);
         targets.push(t);
@@ -226,6 +227,27 @@ export function installSkill({ platforms: platformsArg = "all", project = true, 
   const guidance = readGuidanceSection();
 
   if (dryRun) console.log(`--dry-run: would install agentmap skill (${scope} scope):`);
+
+  // Preflight: validate EVERY platform before writing the FIRST file.
+  //
+  // The loop below writes as it goes, so a platform whose config is malformed
+  // used to throw partway through and leave the earlier platforms installed and
+  // the later ones not — a state that is neither "installed" nor "unchanged",
+  // from a command the user will now re-run against a repo it has already
+  // half-modified. The extras are where that happens: they parse the user's
+  // settings.json / config.toml, which is the one input agentmap does not
+  // control. Running them in dry-run mode first performs the same parse and
+  // shape validation and writes nothing, so a bad file fails clean.
+  //
+  // Skipped when already dry-running (the loop below does this work anyway) and
+  // silenced via `quiet`, since these are checks, not a plan for the user to read.
+  if (!dryRun) {
+    for (const name of names) {
+      const cfg = PLATFORMS[name];
+      if (cfg.projectOnly && globalScope) continue;
+      installExtrasForPlatform(name, cfg, { root, globalScope, dryRun: true, targets: [], quiet: true });
+    }
+  }
 
   for (const name of names) {
     const cfg = PLATFORMS[name];

--- a/test/bin-symlink.test.mjs
+++ b/test/bin-symlink.test.mjs
@@ -16,7 +16,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync, spawnSync } from "node:child_process";
 import { symlinkSync, mkdirSync, readFileSync } from "node:fs";
-import { join, dirname } from "node:path";
+import { join, dirname, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import { makeRepo, gitInit, cleanup, AGENTMAP } from "./helpers.mjs";
 
@@ -29,6 +29,32 @@ const FIXTURE = {
   "src/b.ts": "import { a } from './a';\nexport const b = a + 1;\n",
 };
 
+// Can this platform create a file symlink at all?
+//
+// Windows needs elevation or Developer Mode for that, and npm does not use symlinks
+// there anyway — it writes a .cmd shim that invokes the real path, so argv[1] IS the
+// target and the guard's fast path settles it. Probed once, by actually trying it,
+// rather than branching on process.platform: an elevated Windows runner CAN make the
+// link, and there is no reason to give up the coverage when it can.
+//
+// Where it cannot, the realpathSync branch of the guard is genuinely UNCOVERED on
+// that platform. Measured, not assumed: disabling that branch fails these five tests
+// and leaves the non-canonical-path test below still passing, because Node resolves
+// argv[1] itself and the string-equality fast path answers first. Nothing short of a
+// real symlink reaches it. Stated here so the skip is read as a gap, not as coverage
+// that moved somewhere else.
+const SYMLINKS_OK = (() => {
+  const probe = makeRepo({});
+  try {
+    symlinkSync(join(probe, "target"), join(probe, "link"));
+    return true;
+  } catch (e) {
+    if (process.platform === "win32" && (e.code === "EPERM" || e.code === "ENOSYS")) return false;
+    return true; // any other failure is a real problem — let the tests surface it
+  } finally { cleanup(probe); }
+})();
+const NO_SYMLINKS = { skip: SYMLINKS_OK ? false : "npm uses .cmd shims, not symlinks, here — see the non-canonical-path test" };
+
 // Mirror npm's layout: a .bin/ symlink pointing at the package entry point.
 function linkBin(dir, target, name) {
   const binDir = join(dir, "node_modules", ".bin");
@@ -38,7 +64,7 @@ function linkBin(dir, target, name) {
   return link;
 }
 
-test("bin symlink: --version prints the version (not silent exit 0)", () => {
+test("bin symlink: --version prints the version (not silent exit 0)", NO_SYMLINKS, () => {
   const dir = makeRepo(FIXTURE);
   try {
     gitInit(dir, { commit: true });
@@ -51,7 +77,7 @@ test("bin symlink: --version prints the version (not silent exit 0)", () => {
   } finally { cleanup(dir); }
 });
 
-test("bin symlink: a query command produces real output", () => {
+test("bin symlink: a query command produces real output", NO_SYMLINKS, () => {
   const dir = makeRepo(FIXTURE);
   try {
     gitInit(dir, { commit: true });
@@ -64,7 +90,7 @@ test("bin symlink: a query command produces real output", () => {
   } finally { cleanup(dir); }
 });
 
-test("bin symlink: --install-hooks actually writes the hook", () => {
+test("bin symlink: --install-hooks actually writes the hook", NO_SYMLINKS, () => {
   const dir = makeRepo(FIXTURE);
   try {
     gitInit(dir, { commit: true });
@@ -83,7 +109,7 @@ test("bin symlink: --install-hooks actually writes the hook", () => {
   } finally { cleanup(dir); }
 });
 
-test("bin symlink: --mcp serves the MCP Registry launch contract", () => {
+test("bin symlink: --mcp serves the MCP Registry launch contract", NO_SYMLINKS, () => {
   // server.json tells registry clients to run the npm package with `--mcp`,
   // i.e. through the bin symlink. That path returned zero bytes.
   const dir = makeRepo(FIXTURE);
@@ -103,7 +129,7 @@ test("bin symlink: --mcp serves the MCP Registry launch contract", () => {
   } finally { cleanup(dir); }
 });
 
-test("mcp.mjs run through its own symlink still serves", () => {
+test("mcp.mjs run through its own symlink still serves", NO_SYMLINKS, () => {
   const dir = makeRepo(FIXTURE);
   try {
     gitInit(dir, { commit: true });
@@ -126,4 +152,35 @@ test("importing agentmap.mjs still executes nothing", async () => {
   assert.equal(typeof mod.isDirectRun, "function");
   assert.equal(mod.isDirectRun(new URL(`file://${AGENTMAP}`).href), false,
     "isDirectRun returned true while imported by the test runner — the CLI would run on import");
+});
+
+// The entry guard, exercised WITHOUT a symlink — so this runs everywhere, including
+// the Windows runner where npm ships .cmd shims and file symlinks may be refused.
+//
+// What this does NOT do: reach the realpathSync branch. Node resolves the main
+// module before setting argv[1], so `<dir>/test/../agentmap.mjs` arrives already
+// normalised and the string-equality fast path answers. Verified by disabling the
+// realpath comparison — the five symlink tests above fail and this one still passes.
+// Only a real symlink exercises that branch.
+//
+// What it DOES cover, on every platform including one that refuses symlinks: a user
+// invoking through a path they typed rather than one npm generated — an npm script
+// with a relative path, a wrapper, a monorepo tool composing `..` segments. That has
+// to print something. The failure signature here is the one that hid for 12 releases,
+// exit 0 with empty stdout, so this asserts OUTPUT and never status.
+test("entry guard: a non-canonical argv[1] still runs main()", () => {
+  const dir = makeRepo(FIXTURE);
+  try {
+    gitInit(dir, { commit: true });
+    // <repo>/test/../agentmap.mjs — same file, different string.
+    // Concatenated, not join()ed — join() would normalise the `..` straight back out
+    // and leave the fast path in charge, quietly making this test vacuous.
+    const noncanonical = `${dirname(AGENTMAP)}${sep}test${sep}..${sep}agentmap.mjs`;
+    assert.notEqual(noncanonical, AGENTMAP, "path is already canonical — this test would be vacuous");
+    const stdout = execFileSync(process.execPath, [noncanonical, "--version"], {
+      cwd: dir, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"], timeout: 60_000,
+    });
+    assert.notEqual(stdout.trim(), "", "non-canonical argv[1] printed NOTHING — the entry guard skipped main()");
+    assert.ok(stdout.trim().includes(PKG.version), `expected version ${PKG.version}, got: ${stdout.trim()}`);
+  } finally { cleanup(dir); }
 });

--- a/test/bin-symlink.test.mjs
+++ b/test/bin-symlink.test.mjs
@@ -17,7 +17,7 @@ import assert from "node:assert/strict";
 import { execFileSync, spawnSync } from "node:child_process";
 import { symlinkSync, mkdirSync, readFileSync } from "node:fs";
 import { join, dirname, sep } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { makeRepo, gitInit, cleanup, AGENTMAP } from "./helpers.mjs";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -148,9 +148,17 @@ test("mcp.mjs run through its own symlink still serves", NO_SYMLINKS, () => {
 test("importing agentmap.mjs still executes nothing", async () => {
   // The guard must stay a guard: the realpath fix must not make an IMPORT look
   // like a direct run. argv[1] here is the test runner, not agentmap.mjs.
-  const mod = await import(AGENTMAP);
+  //
+  // pathToFileURL, not a `file://` + path template. On POSIX the two agree, which
+  // is why the template survived until a Windows runner existed; there AGENTMAP is
+  // `D:\a\agentmap\...`, and both forms break — the bare path is rejected by the
+  // ESM loader (ERR_UNSUPPORTED_ESM_URL_SCHEME, protocol 'd:') and `file://D:\a\...`
+  // is not a valid file URL either. pathToFileURL handles the drive letter and the
+  // separators on every platform.
+  const selfUrl = pathToFileURL(AGENTMAP).href;
+  const mod = await import(selfUrl);
   assert.equal(typeof mod.isDirectRun, "function");
-  assert.equal(mod.isDirectRun(new URL(`file://${AGENTMAP}`).href), false,
+  assert.equal(mod.isDirectRun(selfUrl), false,
     "isDirectRun returned true while imported by the test runner — the CLI would run on import");
 });
 

--- a/test/helpers.mjs
+++ b/test/helpers.mjs
@@ -45,7 +45,11 @@ export function gitInit(dir, { commit = false, message = "init" } = {}) {
   g("config", "user.email", "test@example.com");
   g("config", "user.name", "agentmap-test");
   g("config", "commit.gpgsign", "false");
-  g("config", "core.hooksPath", "/dev/null"); // never fire a real hook during tests
+  // Point hooks at a directory that does not exist — git then finds no hooks, which
+  // is the intent. Was "/dev/null"; that happens to work on Windows too (git looks
+  // for a \dev\null directory and finds nothing) but only by accident, and reusing
+  // the same sentinel as the config vars above says what is meant.
+  g("config", "core.hooksPath", NO_GIT_CONFIG);
   if (commit) { g("add", "-A"); g("commit", "-q", "-m", message, "--no-verify"); }
 }
 

--- a/test/helpers.mjs
+++ b/test/helpers.mjs
@@ -49,9 +49,29 @@ export function gitInit(dir, { commit = false, message = "init" } = {}) {
   if (commit) { g("add", "-A"); g("commit", "-q", "-m", message, "--no-verify"); }
 }
 
+// Detach every test's git from the DEVELOPER's git. Without this the suite
+// inherits whatever is in ~/.gitconfig and /etc/gitconfig — `init.defaultBranch`,
+// `core.autocrlf`, `commit.gpgsign`, an `includeIf`, a global `core.hooksPath` —
+// so a test can pass on one machine and fail on another for reasons no assertion
+// mentions. gitInit() already pins the few settings it cares about locally; this
+// closes the rest.
+//
+// Points at a path that does not exist rather than /dev/null: git treats a missing
+// config file as empty everywhere, while /dev/null is not a path on Windows, which
+// the CI matrix now covers.
+const NO_GIT_CONFIG = join(tmpdir(), "agentmap-no-such-gitconfig");
+const GIT_ENV = {
+  GIT_CONFIG_GLOBAL: NO_GIT_CONFIG,
+  GIT_CONFIG_SYSTEM: NO_GIT_CONFIG,
+  GIT_CONFIG_NOSYSTEM: "1",
+};
+
 // Run a raw git command in `dir`. Throws on failure (callers expect git to work).
 export function git(dir, ...args) {
-  return execFileSync("git", args, { cwd: dir, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+  return execFileSync("git", args, {
+    cwd: dir, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"],
+    env: { ...process.env, ...GIT_ENV },
+  });
 }
 
 // Every synchronous CLI invocation below gets a hard ceiling: if agentmap ever

--- a/test/injection-safety.test.mjs
+++ b/test/injection-safety.test.mjs
@@ -109,3 +109,50 @@ test('a literal that DOES exist still matches inertly (positive control)', () =>
   assert.match(r.stdout, /SAFE_LITERAL_TOKEN/, "benign literal not found via content search");
   cleanup(dir);
 });
+
+test("terminal control sequences in matched source are neutralised, not echoed", () => {
+  // Content-search lines are the only raw repository bytes agentmap prints. A text
+  // file can carry ESC sequences that `git grep -I` happily passes through: ESC[2J
+  // clears the screen, and a cursor-up run can overwrite the file:line prefix so a
+  // hit looks like it came from somewhere else. Assert the escape never reaches
+  // stdout on EITHER surface — prose or --json — while the match still lands.
+  const dir = makeRepo({
+    ...FIXTURE,
+    // \x1b[2J = clear screen, \x1b[1A = cursor up, \x07 = bell, \x7f = DEL.
+    "src/evil.ts": `export const E = "ESCAPE_PROBE_LITERAL\x1b[2J\x1b[1A\x07\x7fspoofed";`,
+  });
+  gitInit(dir, { commit: true });
+
+  const prose = run(dir, "--any", "ESCAPE_PROBE_LITERAL");
+  assert.equal(prose.status, 0, `probe literal should be found, got ${prose.status}: ${prose.stderr}`);
+  assert.match(prose.stdout, /evil\.ts/, "the match itself was lost while sanitising");
+  assert.doesNotMatch(prose.stdout, /[\x00-\x08\x0B-\x1F\x7F]/, "a raw control character reached prose stdout");
+
+  const json = run(dir, "--any", "ESCAPE_PROBE_LITERAL", "--json");
+  assert.equal(json.status, 0, `--json probe should exit 0, got ${json.status}: ${json.stderr}`);
+  const obj = JSON.parse(json.stdout);
+  assert.equal(obj.kind, "content", `expected a content result, got ${obj.kind}`);
+  const joined = obj.lines.join("\n");
+  // Parsed back out, so this catches the JSON-escaped form too — JSON.stringify
+  // would have written a \\u001b escape and a consumer echoing the parsed value is exposed.
+  assert.doesNotMatch(joined, /[\x00-\x08\x0B-\x1F\x7F]/, "a raw control character survived into --json lines");
+  assert.match(joined, /ESCAPE_PROBE_LITERAL/, "the match itself was lost in --json");
+  assert.match(joined, /�/, "controls should be replaced with U+FFFD, not silently dropped");
+
+  cleanup(dir);
+});
+
+test("sanitising controls does not eat ordinary tabs in matched lines", () => {
+  // \t is deliberately NOT stripped — it is ordinary source indentation, and
+  // removing it would mangle every tab-indented repo's content-search output.
+  const dir = makeRepo({
+    ...FIXTURE,
+    "src/tabbed.ts": `export function f() {\n\treturn "TAB_PROBE_LITERAL";\n}`,
+  });
+  gitInit(dir, { commit: true });
+  const r = run(dir, "--any", "TAB_PROBE_LITERAL", "--json");
+  assert.equal(r.status, 0, `tab probe should exit 0, got ${r.status}: ${r.stderr}`);
+  const line = JSON.parse(r.stdout).lines.join("\n");
+  assert.match(line, /\t/, "the tab was stripped along with the control characters");
+  cleanup(dir);
+});

--- a/test/install-skill.test.mjs
+++ b/test/install-skill.test.mjs
@@ -3,7 +3,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
-import { makeRepo, run, cleanup } from "./helpers.mjs";
+import { makeRepo, run, runErr, cleanup } from "./helpers.mjs";
 
 const PKG_VERSION = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8")).version;
 
@@ -137,5 +137,72 @@ test("--install-skill is idempotent", () => {
   const dir = makeRepo({});
   assert.equal(run(dir, "--install-skill", "--platform", "claude").status, 0);
   assert.equal(run(dir, "--install-skill", "--platform", "claude").status, 0);
+  cleanup(dir);
+});
+
+// --- installer robustness: a malformed settings.json must not half-install ----
+
+test("a non-object hooks key fails with a named error, not an opaque TypeError", () => {
+  // `settings.hooks ??= {}` only fills null/undefined, so a string sailed through
+  // and threw ".some is not a function" two lines later.
+  const dir = makeRepo({ ".gemini/settings.json": JSON.stringify({ hooks: "nope" }, null, 2) });
+  const r = run(dir, "--install-skill", "--platform", "gemini");
+  assert.notEqual(r.status, 0, "a malformed settings.json should fail the install");
+  const msg = r.stdout + r.stderr;
+  assert.match(msg, /\.gemini\/settings\.json/, "the error does not name the offending file");
+  assert.match(msg, /"hooks" must be an object/, "the error does not name the offending key");
+  assert.doesNotMatch(msg, /is not a function/, "still throwing the opaque TypeError");
+  cleanup(dir);
+});
+
+test("a non-array hooks.BeforeTool fails with a named error", () => {
+  const dir = makeRepo({ ".gemini/settings.json": JSON.stringify({ hooks: { BeforeTool: 42 } }, null, 2) });
+  const r = run(dir, "--install-skill", "--platform", "gemini");
+  assert.notEqual(r.status, 0, "a malformed hooks.BeforeTool should fail the install");
+  assert.match(r.stdout + r.stderr, /"hooks\.BeforeTool" must be an array/, "the error does not name the offending key");
+  cleanup(dir);
+});
+
+test("a malformed config for ONE platform installs nothing for the others", () => {
+  // The whole point of the preflight. Before it, `--install-skill` (all platforms)
+  // wrote Claude/Cursor/Codex first and only then hit Gemini's broken settings.json,
+  // leaving a repo that was neither installed nor untouched.
+  const dir = makeRepo({
+    "src/index.ts": "export function x() { return 1; }",
+    ".gemini/settings.json": JSON.stringify({ hooks: "nope" }, null, 2),
+  });
+  const r = run(dir, "--install-skill");
+  assert.notEqual(r.status, 0, "install should fail while any platform's config is malformed");
+  for (const p of [
+    join(dir, ".claude", "skills", "agentmap", "SKILL.md"),
+    join(dir, ".cursor", "rules", "agentmap.mdc"),
+    join(dir, ".codex", "skills", "agentmap", "SKILL.md"),
+    join(dir, ".opencode", "skills", "agentmap", "SKILL.md"),
+  ]) {
+    assert.equal(existsSync(p), false, `partial install: ${p} was written despite the failure`);
+  }
+  cleanup(dir);
+});
+
+test("comments in settings.json are reported as dropped, not deleted in silence", () => {
+  // JSON.stringify cannot round-trip JSONC. The comments go; the user gets told.
+  const dir = makeRepo({
+    ".gemini/settings.json": '{\n  // keep an eye on this\n  "theme": "dark"\n}\n',
+  });
+  const r = runErr(dir, "--install-skill", "--platform", "gemini");
+  assert.equal(r.status, 0, r.stderr);
+  const msg = r.stdout + r.stderr;
+  assert.match(msg, /contained comments/i, "no warning that JSONC comments were dropped");
+  const after = JSON.parse(readFileSync(join(dir, ".gemini", "settings.json"), "utf8"));
+  assert.equal(after.theme, "dark", "the surrounding settings were not preserved");
+  assert.ok(Array.isArray(after.hooks?.BeforeTool), "the hook was not actually registered");
+  cleanup(dir);
+});
+
+test("a comment-free settings.json triggers no comment warning", () => {
+  const dir = makeRepo({ ".gemini/settings.json": JSON.stringify({ theme: "dark" }, null, 2) });
+  const r = runErr(dir, "--install-skill", "--platform", "gemini");
+  assert.equal(r.status, 0, r.stderr);
+  assert.doesNotMatch(r.stdout + r.stderr, /contained comments/i, "false comment warning on plain JSON");
   cleanup(dir);
 });

--- a/test/install-skill.test.mjs
+++ b/test/install-skill.test.mjs
@@ -3,7 +3,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
-import { makeRepo, run, runErr, cleanup } from "./helpers.mjs";
+import { makeRepo, run, runErr, runWithHome, cleanup } from "./helpers.mjs";
 
 const PKG_VERSION = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8")).version;
 
@@ -83,7 +83,9 @@ test("--install-skill --platform gemini installs GEMINI.md and hooks", () => {
 
 test("--install-skill --global --platform antigravity --dry-run targets ~/.gemini/config/skills", () => {
   const dir = makeRepo({});
-  const r = run(dir, "--install-skill", "--global", "--platform", "antigravity", "--dry-run");
+  const home = makeRepo({});
+  const r = runWithHome(dir, home, "--install-skill", "--global", "--platform", "antigravity", "--dry-run");
+  assert.ok(r.stdout.includes(home), "global paths did not resolve against the fake HOME");
   assert.equal(r.status, 0, r.stderr);
   assert.match(r.stdout, /\.gemini[/\\]config[/\\]skills[/\\]agentmap[/\\]SKILL\.md/);
   cleanup(dir);
@@ -91,7 +93,9 @@ test("--install-skill --global --platform antigravity --dry-run targets ~/.gemin
 
 test("--install-skill --global --platform opencode --dry-run targets ~/.config/opencode/skills and AGENTS.md", () => {
   const dir = makeRepo({});
-  const r = run(dir, "--install-skill", "--global", "--platform", "opencode", "--dry-run");
+  const home = makeRepo({});
+  const r = runWithHome(dir, home, "--install-skill", "--global", "--platform", "opencode", "--dry-run");
+  assert.ok(r.stdout.includes(home), "global paths did not resolve against the fake HOME");
   assert.equal(r.status, 0, r.stderr);
   assert.match(r.stdout, /\.config[/\\]opencode[/\\]skills[/\\]agentmap[/\\]SKILL\.md/);
   assert.match(r.stdout, /\.config[/\\]opencode[/\\]AGENTS\.md/);

--- a/test/post-commit-hook.test.mjs
+++ b/test/post-commit-hook.test.mjs
@@ -14,6 +14,13 @@ import { makeRepo, writeFiles, gitInit, cleanup } from "./helpers.mjs";
 const HERE = dirname(fileURLToPath(import.meta.url));
 const HOOK_SRC = join(HERE, "..", "hooks", "post-commit");
 
+// hooks/post-commit is a POSIX /bin/sh script, and every test below drives it by
+// spawning `sh` directly. `sh` is not a Windows platform binary — git for Windows
+// ships its own bash and runs the hook through that, so what is unavailable on
+// win32 is this harness, not the hook. Skipped explicitly rather than left to fail
+// or, worse, rewritten into something that passes without executing anything.
+const POSIX_ONLY = { skip: process.platform === "win32" ? "hooks/post-commit is a POSIX sh script; sh is unavailable on win32" : false };
+
 // Install the real hook into dir/.git/hooks/post-commit, overriding the
 // core.hooksPath=/dev/null that gitInit sets so the hook actually fires.
 function installHook(dir) {
@@ -27,7 +34,7 @@ function installHook(dir) {
 // (the hook runs it via `node ./agentmap.mjs`, which treats .mjs as a module).
 const PAYLOAD = 'import{writeFileSync}from"node:fs";writeFileSync("PWNED","x")\n';
 
-test("planted ./agentmap.mjs is NOT executed by the post-commit hook by default", () => {
+test("planted ./agentmap.mjs is NOT executed by the post-commit hook by default", POSIX_ONLY, () => {
   const dir = makeRepo({ "agentmap.mjs": PAYLOAD, "a.ts": "export const a = 1;\n" });
   gitInit(dir);
   installHook(dir);
@@ -41,7 +48,7 @@ test("planted ./agentmap.mjs is NOT executed by the post-commit hook by default"
   cleanup(dir);
 });
 
-test("AGENTMAP_HOOK_ALLOW_LOCAL=1 opts in to running ./agentmap.mjs", () => {
+test("AGENTMAP_HOOK_ALLOW_LOCAL=1 opts in to running ./agentmap.mjs", POSIX_ONLY, () => {
   const dir = makeRepo({ "agentmap.mjs": PAYLOAD, "a.ts": "export const a = 1;\n" });
   gitInit(dir);
   installHook(dir);
@@ -70,7 +77,7 @@ const runHook = (dir) => execFileSync("sh", [join(dir, ".git", "hooks", "post-co
   cwd: dir, env: { ...process.env, AGENTMAP_HOOK_ALLOW_LOCAL: "1" }, stdio: "ignore",
 });
 
-test("a held lock makes the hook skip instead of piling on", () => {
+test("a held lock makes the hook skip instead of piling on", POSIX_ONLY, () => {
   const dir = makeRepo({ "agentmap.mjs": PAYLOAD, "a.ts": "export const a = 1;\n" });
   gitInit(dir);
   installHook(dir);
@@ -82,7 +89,7 @@ test("a held lock makes the hook skip instead of piling on", () => {
   cleanup(dir);
 });
 
-test("a lock older than 10 minutes is cleared so refresh cannot stay dead", () => {
+test("a lock older than 10 minutes is cleared so refresh cannot stay dead", POSIX_ONLY, () => {
   // Without this, one killed rebuild would disable auto-refresh permanently —
   // a worse failure than the leak it guards against, and a silent one.
   const dir = makeRepo({ "agentmap.mjs": PAYLOAD, "a.ts": "export const a = 1;\n" });
@@ -123,7 +130,7 @@ const WRAPPER = [
   'setInterval(()=>{},1000);\n',
 ].join("");
 
-test("the timeout reaps a hung runner's grandchild, not just the wrapper", () => {
+test("the timeout reaps a hung runner's grandchild, not just the wrapper", POSIX_ONLY, () => {
   const dir = makeRepo({ "agentmap.mjs": WRAPPER, "a.ts": "export const a = 1;\n" });
   const beat = join(dir, "HEARTBEAT");
   try {

--- a/test/ranking-quality.test.mjs
+++ b/test/ranking-quality.test.mjs
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: MIT
+// Contract — ranking QUALITY, not just ranking stability.
+//
+// determinism.test.mjs proves two builds agree with each other and that a known
+// file appears SOMEWHERE in hubs. Neither catches a ranking that is stably,
+// reproducibly wrong: invert the comparator and every one of those assertions
+// still passes. These tests assert ORDER against a fixture whose in-degrees are
+// constructed and therefore known in advance.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { makeRepo, gitInit, run, cleanup } from "./helpers.mjs";
+
+const MAP = ".claude/agentmap/map.json";
+
+// A deliberate star: one file everything imports, one middling file, one leaf
+// nobody imports. In-degrees are 5 / 2 / 0, unambiguous by construction.
+const FIXTURE = {
+  "tsconfig.json": JSON.stringify({ compilerOptions: { allowJs: true }, include: ["**/*.ts"] }),
+  "src/core.ts": `export const core = 1;`,
+  "src/mid.ts": `export const mid = 2;`,
+  "src/leaf.ts": `export const leaf = 3;`,
+  "src/a.ts": `import { core } from "./core";\nimport { mid } from "./mid";\nexport const a = core + mid;`,
+  "src/b.ts": `import { core } from "./core";\nimport { mid } from "./mid";\nexport const b = core + mid;`,
+  "src/c.ts": `import { core } from "./core";\nexport const c = core;`,
+  "src/d.ts": `import { core } from "./core";\nexport const d = core;`,
+  "src/e.ts": `import { core } from "./core";\nexport const e = core;`,
+};
+
+// hubs entries are display strings: "path (deg N, pr X)". Rank = array position.
+const rankOf = (hubs, path) => hubs.findIndex((h) => h.startsWith(`${path} `) || h === path);
+const degOf = (hubs, path) => {
+  const e = hubs.find((h) => h.startsWith(`${path} `));
+  const m = e && e.match(/deg (\d+)/);
+  return m ? Number(m[1]) : null;
+};
+
+function buildHubs() {
+  const dir = makeRepo(FIXTURE);
+  gitInit(dir, { commit: true });
+  const r = run(dir);
+  assert.equal(r.status, 0, `build failed: ${r.stderr}`);
+  const hubs = JSON.parse(readFileSync(join(dir, MAP), "utf8")).hubs;
+  return { dir, hubs };
+}
+
+test("the most-imported file ranks FIRST, not merely somewhere in hubs", () => {
+  const { dir, hubs } = buildHubs();
+  assert.ok(hubs.length > 0, "no hubs produced");
+  assert.ok(
+    hubs[0].startsWith("src/core.ts "),
+    `hubs[0] should be the 5-importer file, got: ${hubs[0]}\nfull: ${JSON.stringify(hubs)}`,
+  );
+  cleanup(dir);
+});
+
+test("in-degree is reported accurately for the constructed graph", () => {
+  // Guards the number the ordering is derived from, so a correct order built on a
+  // wrong degree still fails loudly.
+  const { dir, hubs } = buildHubs();
+  assert.equal(degOf(hubs, "src/core.ts"), 5, `core.ts should have 5 dependents: ${JSON.stringify(hubs)}`);
+  assert.equal(degOf(hubs, "src/mid.ts"), 2, `mid.ts should have 2 dependents: ${JSON.stringify(hubs)}`);
+  cleanup(dir);
+});
+
+test("a leaf nobody imports never outranks a file with importers", () => {
+  const { dir, hubs } = buildHubs();
+  const leaf = rankOf(hubs, "src/leaf.ts");
+  const mid = rankOf(hubs, "src/mid.ts");
+  assert.notEqual(mid, -1, `mid.ts (2 importers) missing from hubs: ${JSON.stringify(hubs)}`);
+  // Absent is fine — a leaf has no claim on the list at all. Present-and-higher is not.
+  if (leaf !== -1) {
+    assert.ok(leaf > mid, `leaf.ts (0 importers) outranked mid.ts (2 importers): ${JSON.stringify(hubs)}`);
+  }
+  cleanup(dir);
+});
+
+test("hub order is monotonic in in-degree for this fixture", () => {
+  // The whole point: an inverted or scrambled comparator survives every
+  // determinism assertion and dies here.
+  const { dir, hubs } = buildHubs();
+  const degs = hubs.map((h) => { const m = h.match(/deg (\d+)/); return m ? Number(m[1]) : null; })
+    .filter((d) => d !== null);
+  for (let i = 1; i < degs.length; i++) {
+    assert.ok(degs[i] <= degs[i - 1], `hubs are not ordered by descending degree at ${i}: ${JSON.stringify(hubs)}`);
+  }
+  cleanup(dir);
+});
+
+test("--symbols ranks the most-referenced export above a single-use one", () => {
+  // Same idea one level down: symbol ranking, not file ranking.
+  const { dir } = buildHubs();
+  const r = run(dir, "--symbols", "20", "--json");
+  assert.equal(r.status, 0, `--symbols failed: ${r.stderr}`);
+  const names = JSON.parse(r.stdout).symbols.map((s) => s.name);
+  const core = names.indexOf("core"), mid = names.indexOf("mid");
+  assert.notEqual(core, -1, `"core" missing from ranked symbols: ${JSON.stringify(names)}`);
+  if (mid !== -1) {
+    assert.ok(core < mid, `"core" (5 referencing files) ranked below "mid" (2): ${JSON.stringify(names)}`);
+  }
+  cleanup(dir);
+});

--- a/test/version-lockstep.test.mjs
+++ b/test/version-lockstep.test.mjs
@@ -91,3 +91,38 @@ test("the Node engines floor and the README badge agree", () => {
     `README badge says node >=${badge[1]} but package.json engines says >=${floor}`,
   );
 });
+
+// --- release hygiene: the two things a release commit is supposed to carry -----
+//
+// ROADMAP proposed release-please/changesets to fix "the recurring
+// missing-CHANGELOG-entry problem (and the lockfile-version drift just seen in
+// aa62353)". Both are checkable directly, so these two tests close that item
+// without a dependency tree or a changeset file per PR. Neither tool was adopted;
+// see the roadmap entry for the reasoning.
+
+test("CHANGELOG.md documents the version in package.json", () => {
+  // The version in package.json is always the LAST released one, so this holds
+  // continuously — not just at release time. Bumping the version without writing
+  // the section fails here, in `npm test`, rather than being noticed after publish
+  // when the release notes are already public.
+  const changelog = readFileSync(join(ROOT, "CHANGELOG.md"), "utf8");
+  const heading = new RegExp(`^##\\s*\\[?${VERSION.replace(/\./g, "\\.")}\\]?`, "m");
+  assert.match(
+    changelog,
+    heading,
+    `CHANGELOG.md has no "## [${VERSION}]" section. Add the entry in the same commit as the version bump.`,
+  );
+});
+
+test("package-lock.json tracks package.json", () => {
+  // Bumping the version without re-running npm install leaves the lockfile
+  // declaring the old one in TWO places. `npm ci` does not catch this — it
+  // validates the dependency tree, not the root package's own version — so it
+  // shipped once already.
+  const lock = read("package-lock.json");
+  assert.equal(lock.version, VERSION, "package-lock.json .version drifted — run `npm install` after the bump");
+  assert.equal(
+    lock.packages?.[""]?.version, VERSION,
+    'package-lock.json .packages[""].version drifted — run `npm install` after the bump',
+  );
+});

--- a/test/version-lockstep.test.mjs
+++ b/test/version-lockstep.test.mjs
@@ -105,12 +105,22 @@ test("CHANGELOG.md documents the version in package.json", () => {
   // continuously — not just at release time. Bumping the version without writing
   // the section fails here, in `npm test`, rather than being noticed after publish
   // when the release notes are already public.
+  // Parse each heading and compare STRINGS, rather than building a RegExp out of
+  // VERSION. The first draft did `VERSION.replace(/\./g, "\\.")`, which CodeQL
+  // flagged as js/incomplete-sanitization, correctly: escaping only `.` leaves
+  // every other metacharacter — and the backslash itself — unescaped. Not
+  // exploitable here (the test above pins VERSION to bare semver, and the input is
+  // our own package.json), but a half-escape is the kind of thing that gets copied
+  // somewhere it does matter. Comparing parsed strings needs no escaping at all.
   const changelog = readFileSync(join(ROOT, "CHANGELOG.md"), "utf8");
-  const heading = new RegExp(`^##\\s*\\[?${VERSION.replace(/\./g, "\\.")}\\]?`, "m");
-  assert.match(
-    changelog,
-    heading,
-    `CHANGELOG.md has no "## [${VERSION}]" section. Add the entry in the same commit as the version bump.`,
+  const versions = changelog
+    .split("\n")
+    .map((line) => line.match(/^##(?!#)\s*\[?([^\]\s]+)\]?/)) // (?!#) so ### subheads do not report as "#"
+    .filter(Boolean)
+    .map((m) => m[1]);
+  assert.ok(
+    versions.includes(VERSION),
+    `CHANGELOG.md has no "## [${VERSION}]" section. Add the entry in the same commit as the version bump. Found: ${versions.slice(0, 5).join(", ")}`,
   );
 });
 


### PR DESCRIPTION
Works the open backlog end to end. 11 commits, each independently reviewable.

## What landed

| Area | Change |
|---|---|
| Benchmark honesty | Disclose the D+F skew (`Excl. D+F` column: 89.8% / 96.4% / 73.1%, 93.7% pooled), reconcile the blast-radius row with `EVAL.md`, validate `chars/4` against a real tokenizer |
| Security | Neutralise C0/DEL control sequences in content-search output on both surfaces; document the two content-search guards |
| CI | Windows + macOS added to the test matrix; typecheck and coverage gates added |
| Correctness | `--symbols N` no longer claims a count it did not return; Gemini global install on Windows no longer writes to a path nothing reads; a malformed config can no longer leave a half-installed skill; JSONC comment loss is now reported |
| Tests | Ranking **order** assertions, env isolation, release-hygiene gates |
| Housekeeping | One `walkSources()` instead of two copies; `CODE_OF_CONDUCT.md` |

475 → 490 tests. Typecheck clean. Coverage 93.77% lines / 76.13% branches.

## Two items were refuted, not implemented

- **Prune `rankSymbols` cross-product** — measured on 5 repos (49–409 files). Largest edge list 2,533; most definers for one identifier 17. Pruning at `defCount>20` drops **0 edges on every repo**; pruning low enough to matter would delete 78.7% of zod's graph including real identifiers.
- **Memory-ceiling warning** — built, measured, reverted. Under a forced 150 MB ceiling a probe firing every iteration logged **one** sample before the OOM, reading **42%** of the limit. The process dies inside a single `getExportedDeclarations()`, finer than one loop iteration. No sampling rate or threshold reaches it. `agentmap.mjs` is byte-identical to before the attempt.

## Declined, with reasoning recorded in ROADMAP

changesets (two lockstep tests cover both named symptoms), ESLint (`checkJs` covers the correctness class), `FUNDING.yml` (maintainer's call), a neutral `.agentmap/` cache path (permanent dual-read path for a cosmetic gain), and an eval step in CI (it clones upstream repos).

## Known gap, stated rather than papered over

Where a platform refuses file symlinks, the `realpathSync` branch of the entry guard is **uncovered**. Verified by negative control: disabling that branch fails the five symlink tests while the non-canonical-path test still passes, because Node resolves `argv[1]` before setting it. The comments say so.

## Why this is a PR

`AGENTS.md` requires it for code changes — and Windows has never run this suite, so CI here is the actual verification.